### PR TITLE
fix: issues in move ordering and search

### DIFF
--- a/src/bin/byte-knight/engine.rs
+++ b/src/bin/byte-knight/engine.rs
@@ -19,7 +19,6 @@ impl ByteKnight {
         println!("Searching with params: {}", search_params);
         let mut search = search::Search::new(*search_params);
         let result = search.search(board);
-        // TODO: Print out information about the search
         result.best_move
     }
 }

--- a/src/bin/byte-knight/evaluation.rs
+++ b/src/bin/byte-knight/evaluation.rs
@@ -65,6 +65,7 @@ impl Evaluation {
             score += 1000 * mv.captured_piece().unwrap() as i64 - mv.piece() as i64
         }
 
-        score
+        // negate the score to get the best move first
+        -score
     }
 }

--- a/src/bin/byte-knight/score.rs
+++ b/src/bin/byte-knight/score.rs
@@ -1,6 +1,6 @@
 use std::{
     fmt::{self, Display, Formatter},
-    ops::{AddAssign, Neg},
+    ops::{Add, AddAssign, Neg},
 };
 
 use uci_parser::UciScore;
@@ -51,5 +51,21 @@ impl AddAssign for Score {
 impl AddAssign<i64> for Score {
     fn add_assign(&mut self, other: i64) {
         self.0 += other;
+    }
+}
+
+impl Add for Score {
+    type Output = Score;
+
+    fn add(self, other: Score) -> Score {
+        Score(self.0 + other.0)
+    }
+}
+
+impl Add<i64> for Score {
+    type Output = Score;
+
+    fn add(self, other: i64) -> Score {
+        Score(self.0 + other)
     }
 }

--- a/src/bin/byte-knight/search.rs
+++ b/src/bin/byte-knight/search.rs
@@ -210,7 +210,7 @@ impl Search {
 
     fn negamax(
         self: &mut Self,
-        board: &mut Board,
+        board: &Board,
         depth: i64,
         ply: i64,
         mut alpha: Score,
@@ -263,9 +263,14 @@ impl Search {
 
         // loop through all moves
         for mv in sorted_moves {
-            if board.make_move_unchecked(mv).is_ok() {
-                let score = -self.negamax(board, depth - 1, ply + 1, -beta, -alpha, max_depth);
-                board.unmake_move().unwrap();
+            let mut new_board = board.clone();
+
+            if new_board.make_move_unchecked(mv).is_ok() {
+                let score = if new_board.is_draw() {
+                    Score::DRAW
+                } else {
+                    -self.negamax(&mut new_board, depth - 1, ply + 1, -beta, -alpha, max_depth)
+                };
 
                 if score > best_score {
                     best_score = score;
@@ -308,7 +313,7 @@ impl Search {
 
     fn quiescence(
         self: &mut Self,
-        board: &mut Board,
+        board: &Board,
         ply: i64,
         mut alpha: Score,
         beta: Score,


### PR DESCRIPTION
## Fixed
- Issues with move ordering
- Issues in search 

## Added
- MVV_LVA table with general values

## Changed
- Disabled qsearch for now. Will come back in a future PR

```
Elo   | 114.30 +- 19.23 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.53 (-2.94, 2.94) [0.00, 10.00]
Games | N: 318 W: 108 L: 7 D: 203
Penta | [0, 3, 62, 84, 10]
https://developerpaul123.pythonanywhere.com/test/7/
```

bench: 8752858