### PR TITLE
feat: add support  for basic search cancelation 

### DIFF
--- a/src/bin/byte-knight/bench.rs
+++ b/src/bin/byte-knight/bench.rs
@@ -1,3 +1,17 @@
+/*
+ * bench.rs
+ * Part of the byte-knight project
+ * Created Date: Thursday, November 21st 2024
+ * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
+ * -----
+ * Last Modified: Thu Nov 21 2024
+ * -----
+ * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
+ * GNU General Public License v3.0 or later
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * 
+ */
+
 use chess::board::Board;
 
 use crate::search::{Search, SearchParameters};

--- a/src/bin/byte-knight/bench.rs
+++ b/src/bin/byte-knight/bench.rs
@@ -148,13 +148,13 @@ pub(crate) fn bench(depth: u8, epd_file: &Option<String>) {
     };
 
     let mut nodes = 0u64;
-    let mut search = Search::new(config);
+    let mut search = Search::new(&config);
 
     for bench in benchmark_strings {
         let fen: &str = bench.split(";").next().unwrap();
         let mut board = Board::from_fen(fen).unwrap();
 
-        let result = search.search(&mut board);
+        let result = search.search(&mut board, None);
         nodes += result.nodes;
     }
 

--- a/src/bin/byte-knight/defs.rs
+++ b/src/bin/byte-knight/defs.rs
@@ -9,9 +9,10 @@ const BANNER: &str = r#"
 
 pub struct About;
 impl About {
-    pub const NAME: &'static str = "ByteKnight";
-    pub const VERSION: &'static str = "0.1.0";
-    pub const SHORT_DESCRIPTION: &'static str = "ByteKnight is a UCI compliant chess engine.";
+    pub const NAME: &'static str = "byte-knight";
+    pub const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+    pub const EMAIL: &'static str = "developer.paul.123@gmail.com";
+    pub const SHORT_DESCRIPTION: &'static str = "byte-knight is a UCI compliant chess engine.";
     pub const AUTHORS: &'static str = "Paul T. (DeveloperPaul123)";
     pub const BANNER: &'static str = BANNER;
 }

--- a/src/bin/byte-knight/defs.rs
+++ b/src/bin/byte-knight/defs.rs
@@ -1,3 +1,17 @@
+/*
+ * defs.rs
+ * Part of the byte-knight project
+ * Created Date: Friday, November 8th 2024
+ * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
+ * -----
+ * Last Modified: Thu Nov 21 2024
+ * -----
+ * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
+ * GNU General Public License v3.0 or later
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * 
+ */
+
 #[rustfmt::skip]
 const BANNER: &str = r#"
  _         _           _        _      _   _   

--- a/src/bin/byte-knight/engine.rs
+++ b/src/bin/byte-knight/engine.rs
@@ -1,3 +1,17 @@
+/*
+ * engine.rs
+ * Part of the byte-knight project
+ * Created Date: Friday, November 15th 2024
+ * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
+ * -----
+ * Last Modified: Thu Nov 21 2024
+ * -----
+ * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
+ * GNU General Public License v3.0 or later
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * 
+ */
+
 use std::io::{self, Write};
 
 use chess::board::Board;

--- a/src/bin/byte-knight/evaluation.rs
+++ b/src/bin/byte-knight/evaluation.rs
@@ -1,3 +1,17 @@
+/*
+ * evaluation.rs
+ * Part of the byte-knight project
+ * Created Date: Thursday, November 21st 2024
+ * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
+ * -----
+ * Last Modified: Thu Nov 21 2024
+ * -----
+ * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
+ * GNU General Public License v3.0 or later
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * 
+ */
+
 use chess::{
     board::Board, definitions::NumberOf, move_generation::MoveGenerator, moves::Move,
     pieces::Piece, side::Side,

--- a/src/bin/byte-knight/input_handler.rs
+++ b/src/bin/byte-knight/input_handler.rs
@@ -13,7 +13,7 @@
  */
 
 use std::{
-    io::{stdin, BufRead, Write},
+    io::{stdin, BufRead},
     str::FromStr,
     sync::mpsc::{self, Receiver, Sender},
 };
@@ -64,10 +64,10 @@ impl InputHandler {
                             break;
                         }
                     } else {
-                        writeln!(std::io::stderr(), "Invalid UCI command: {}", line).unwrap();
+                        eprintln!("Invalid UCI command: {}", line);
                     }
                 } else {
-                    writeln!(std::io::stderr(), "Error reading from stdin").unwrap();
+                    eprintln!("Error reading from stdin");
                 }
             }
         });
@@ -89,7 +89,7 @@ impl InputHandler {
 
     /// Signal to the worker thread that it should stop. This method does not block the calling
     /// thread.
-    pub(crate) fn stop(&mut self) {
+    pub(crate) fn exit(&mut self) {
         self.worker.stop();
     }
 }

--- a/src/bin/byte-knight/input_handler.rs
+++ b/src/bin/byte-knight/input_handler.rs
@@ -1,0 +1,105 @@
+use std::{
+    io::{stdin, BufRead, Write},
+    str::FromStr,
+    sync::mpsc::{self, Receiver, Sender},
+};
+
+use uci_parser::UciCommand;
+
+use crate::worker_thread::WorkerThread;
+
+#[derive(Debug)]
+pub(crate) struct InputHandler {
+    worker: WorkerThread<UciCommand>,
+}
+
+impl InputHandler {
+    /// Creates a new [`InputHandler`]. The input handler reads from stdin and sends the parsed UCI
+    /// commands to the receiver end of the channel via the sender. Creating a new [`InputHandler`]
+    /// spawns a new worker thread. The thread starts upon creation.
+    ///
+    /// # Panics
+    ///
+    /// Panics if there is an error spawning the worker thread.
+    ///
+    /// # Returns
+    ///
+    /// A new [`InputHandler`] instance.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use engine::InputHandler;
+    /// let input_handler = InputHandler::new();
+    /// let receiver = input_handler.receiver();
+    /// ```
+    ///
+    pub(crate) fn new() -> InputHandler {
+        let (sender, receiver) = mpsc::channel();
+        let worker = WorkerThread::new(sender.clone(), receiver, move |stop_flag| {
+            let stdin = stdin();
+            let mut input = stdin.lock().lines();
+            while !stop_flag.load(std::sync::atomic::Ordering::Relaxed) {
+                if let Some(Ok(line)) = input.next() {
+                    let command = UciCommand::from_str(line.as_str());
+                    if let Ok(command) = command {
+                        let cmd = command.clone();
+                        sender.send(command).unwrap();
+                        // manually break the loop if the command is "quit"
+                        if cmd == UciCommand::Quit {
+                            break;
+                        }
+                    } else {
+                        writeln!(std::io::stderr(), "Invalid UCI command: {}", line).unwrap();
+                    }
+                } else {
+                    writeln!(std::io::stderr(), "Error reading from stdin").unwrap();
+                }
+            }
+        });
+        InputHandler { worker }
+    }
+
+    fn sender(&self) -> Sender<UciCommand> {
+        self.worker.sender()
+    }
+
+    /// Returns a reference to the receiver end of the channel.
+    ///
+    /// # Returns
+    ///
+    /// A reference to the receiver end of the channel.
+    pub(crate) fn receiver(&self) -> &Receiver<UciCommand> {
+        self.worker.receiver()
+    }
+
+    /// Signal to the worker thread that it should stop. This method does not block the calling
+    /// thread.
+    pub(crate) fn stop(&mut self) {
+        self.worker.stop();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_input_handler() {
+        let input_handler = InputHandler::new();
+        let sender = input_handler.sender();
+
+        sender.send(UciCommand::Uci).unwrap();
+        sender.send(UciCommand::IsReady).unwrap();
+        sender.send(UciCommand::UciNewGame).unwrap();
+
+        let inputs: Vec<UciCommand>;
+        let receiver = input_handler.receiver();
+        inputs = receiver.iter().take(3).collect();
+
+        assert_eq!(
+            inputs,
+            vec![UciCommand::Uci, UciCommand::IsReady, UciCommand::UciNewGame]
+        );
+    }
+}

--- a/src/bin/byte-knight/input_handler.rs
+++ b/src/bin/byte-knight/input_handler.rs
@@ -1,3 +1,17 @@
+/*
+ * input_handler.rs
+ * Part of the byte-knight project
+ * Created Date: Monday, November 18th 2024
+ * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
+ * -----
+ * Last Modified: Thu Nov 21 2024
+ * -----
+ * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
+ * GNU General Public License v3.0 or later
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ */
+
 use std::{
     io::{stdin, BufRead, Write},
     str::FromStr,

--- a/src/bin/byte-knight/main.rs
+++ b/src/bin/byte-knight/main.rs
@@ -16,21 +16,21 @@ mod bench;
 mod defs;
 mod engine;
 mod evaluation;
+mod input_handler;
 mod psqt;
 mod score;
 mod search;
+mod search_thread;
 mod tt_table;
+mod worker_thread;
 
 use defs::About;
 use engine::ByteKnight;
-use search::SearchParameters;
-use uci_parser::{UciCommand, UciInfo, UciMove, UciOption, UciResponse};
 
-use std::{process::exit, str::FromStr};
+use std::process::exit;
 
-use chess::{board::Board, moves::Move, pieces::SQUARE_NAME};
 use clap::{Parser, Subcommand};
-use std::io::{self, BufRead, Write};
+use std::io::{self, Write};
 
 #[derive(Parser)]
 #[command(
@@ -54,107 +54,14 @@ enum Command {
     },
 }
 
-fn square_index_to_uci_square(square: u8) -> uci_parser::Square {
-    uci_parser::Square::from_str(SQUARE_NAME[square as usize]).unwrap()
-}
-
-fn move_to_uci_move(mv: &Move) -> UciMove {
-    let promotion = mv.promotion_piece().map(|p| p.as_char());
-
-    match promotion {
-        Some(promotion) => UciMove {
-            src: square_index_to_uci_square(mv.from()),
-            dst: square_index_to_uci_square(mv.to()),
-            promote: Some(uci_parser::Piece::from_str(&promotion.to_string()).unwrap()),
-        },
-        None => UciMove {
-            src: square_index_to_uci_square(mv.from()),
-            dst: square_index_to_uci_square(mv.to()),
-            promote: None,
-        },
-    }
-}
-
 fn run_uci() {
-    let stdin: io::Stdin = io::stdin();
-    let stdout = io::stdout();
-    let mut stdout = stdout.lock();
-    let mut input = stdin.lock().lines();
-    let mut board = Board::default_board();
-
     let mut engine = ByteKnight::new();
-    writeln!(stdout, "{}", About::BANNER).unwrap();
-
-    loop {
-        if let Some(Ok(line)) = input.next() {
-            let command = UciCommand::from_str(line.as_str());
-            match command {
-                Ok(UciCommand::Uci) => {
-                    let id = UciResponse::Id {
-                        name: About::NAME,
-                        author: About::AUTHORS,
-                    };
-
-                    let options = vec![
-                        UciOption::spin("Hash", 16, 1, 1024),
-                        UciOption::spin("Threads", 1, 1, 1),
-                    ];
-                    // TODO: Actually implement the hash option
-                    for option in options {
-                        writeln!(stdout, "{}", UciResponse::Option(option)).unwrap();
-                    }
-                    writeln!(stdout, "{}", id).unwrap();
-                    writeln!(stdout, "{}", UciResponse::<String>::UciOk).unwrap();
-                }
-                Ok(UciCommand::Quit) => {
-                    exit(0);
-                }
-                Ok(UciCommand::UciNewGame) => {
-                    board = Board::default_board();
-                }
-                Ok(UciCommand::IsReady) => {
-                    writeln!(stdout, "{}", UciResponse::<String>::ReadyOk).unwrap();
-                }
-                Ok(UciCommand::Position { fen, moves }) => {
-                    match fen {
-                        None => {
-                            board = Board::default_board();
-                        }
-                        Some(fen) => {
-                            board = Board::from_fen(fen.as_str()).unwrap();
-                        }
-                    }
-
-                    for mv in moves {
-                        board.make_uci_move(&mv.to_string()).unwrap();
-                    }
-
-                    // TODO: String output of board
-                    // writeln!(stdout, "{}", Board::to_string(&board)).unwrap();
-                }
-                Ok(UciCommand::Go(search_options)) => {
-                    let info = UciInfo::default().string(format!("searching {}", board.to_fen()));
-                    writeln!(stdout, "{}", UciResponse::info(info)).unwrap();
-                    let search_params = SearchParameters::new(&search_options, &board);
-                    let best_move = engine.think(&mut board, &search_params);
-                    let move_output = UciResponse::BestMove {
-                        bestmove: best_move.map_or(None, |bot_move| {
-                            Some(move_to_uci_move(&bot_move).to_string())
-                        }),
-                        ponder: None,
-                    };
-                    writeln!(
-                        stdout,
-                        "{}",
-                        // TODO: Ponder
-                        move_output
-                    )
-                    .unwrap();
-                }
-                _ => (),
-            }
-
-            stdout.flush().unwrap();
+    let engine_run_result = engine.run();
+    match engine_run_result {
+        Ok(_) => (),
+        Err(e) => {
+            writeln!(io::stderr(), "Error running engine: {}", e).unwrap();
+            exit(1);
         }
     }
 }

--- a/src/bin/byte-knight/main.rs
+++ b/src/bin/byte-knight/main.rs
@@ -4,7 +4,7 @@
  * Created Date: Wednesday, August 14th 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified:
+ * Last Modified: Thu Nov 21 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later

--- a/src/bin/byte-knight/psqt.rs
+++ b/src/bin/byte-knight/psqt.rs
@@ -1,3 +1,17 @@
+/*
+ * psqt.rs
+ * Part of the byte-knight project
+ * Created Date: Thursday, November 21st 2024
+ * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
+ * -----
+ * Last Modified: Thu Nov 21 2024
+ * -----
+ * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
+ * GNU General Public License v3.0 or later
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * 
+ */
+
 use chess::{bitboard_helpers, board::Board, side::Side};
 
 use crate::score::Score;

--- a/src/bin/byte-knight/score.rs
+++ b/src/bin/byte-knight/score.rs
@@ -1,3 +1,17 @@
+/*
+ * score.rs
+ * Part of the byte-knight project
+ * Created Date: Thursday, November 14th 2024
+ * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
+ * -----
+ * Last Modified: Thu Nov 21 2024
+ * -----
+ * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
+ * GNU General Public License v3.0 or later
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * 
+ */
+
 use std::{
     fmt::{self, Display, Formatter},
     ops::{Add, AddAssign, Neg},

--- a/src/bin/byte-knight/search.rs
+++ b/src/bin/byte-knight/search.rs
@@ -1,3 +1,17 @@
+/*
+ * search.rs
+ * Part of the byte-knight project
+ * Created Date: Thursday, November 21st 2024
+ * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
+ * -----
+ * Last Modified: Thu Nov 21 2024
+ * -----
+ * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
+ * GNU General Public License v3.0 or later
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * 
+ */
+
 use std::{
     fmt::Display,
     sync::{

--- a/src/bin/byte-knight/search.rs
+++ b/src/bin/byte-knight/search.rs
@@ -1,5 +1,9 @@
 use std::{
     fmt::Display,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
     time::{Duration, Instant},
     u64,
 };
@@ -50,7 +54,7 @@ impl Display for SearchResult {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct SearchParameters {
     pub max_depth: u8,
     pub start_time: Instant,
@@ -125,26 +129,34 @@ pub(crate) struct Search {
     nodes: u64,
     parameters: SearchParameters,
     eval: Evaluation,
+    stop_flag: Option<Arc<AtomicBool>>,
 }
 
 impl Default for Search {
     fn default() -> Self {
-        Search::new(SearchParameters::default())
+        Search::new(&SearchParameters::default())
     }
 }
 
 impl Search {
-    pub fn new(parameters: SearchParameters) -> Self {
+    pub fn new(parameters: &SearchParameters) -> Self {
         Search {
             transposition_table: TranspositionTable::from_size_in_mb(64),
             move_gen: MoveGenerator::new(),
             nodes: 0,
-            parameters,
+            parameters: parameters.clone(),
             eval: Evaluation::new(),
+            stop_flag: None,
         }
     }
 
-    pub(crate) fn search(self: &mut Self, board: &mut Board) -> SearchResult {
+    pub(crate) fn search(
+        self: &mut Self,
+        board: &mut Board,
+        stop_flag: Option<Arc<AtomicBool>>,
+    ) -> SearchResult {
+        self.stop_flag = stop_flag;
+
         let info = UciInfo::default().string(format!("searching {}", self.parameters));
         let message = UciResponse::info(info);
         println!("{}", message);
@@ -158,6 +170,7 @@ impl Search {
     fn should_stop_searching(self: &Self) -> bool {
         self.parameters.start_time.elapsed() >= self.parameters.hard_timeout // hard timeout
         || self.nodes >= self.parameters.max_nodes // node limit reached
+        || self.stop_flag.as_ref().is_some_and(|f| f.load(Ordering::Relaxed)) // stop flag set
     }
 
     fn iterative_deepening(self: &mut Self, board: &mut Board) -> SearchResult {
@@ -438,8 +451,8 @@ mod tests {
             ..Default::default()
         };
 
-        let mut search = Search::new(config);
-        let res = search.search(&mut board.clone());
+        let mut search = Search::new(&config);
+        let res = search.search(&mut board.clone(), None);
         // b6a7
         assert_eq!(
             res.best_move.unwrap().to_long_algebraic(),
@@ -456,8 +469,8 @@ mod tests {
             ..Default::default()
         };
 
-        let mut search = Search::new(config);
-        let res = search.search(&mut board);
+        let mut search = Search::new(&config);
+        let res = search.search(&mut board, None);
 
         assert_eq!(res.best_move.unwrap().to_long_algebraic(), "b8a8")
     }
@@ -468,8 +481,8 @@ mod tests {
         let mut board = Board::from_fen(&fen).unwrap();
         let config = SearchParameters::default();
 
-        let mut search = Search::new(config);
-        let res = search.search(&mut board);
+        let mut search = Search::new(&config);
+        let res = search.search(&mut board, None);
         assert!(res.best_move.is_none());
         assert_eq!(res.score, Score::DRAW);
     }
@@ -483,8 +496,8 @@ mod tests {
             ..Default::default()
         };
 
-        let mut search = Search::new(config);
-        let res = search.search(&mut board);
+        let mut search = Search::new(&config);
+        let res = search.search(&mut board, None);
 
         assert!(res.best_move.is_some());
         assert!(config.start_time.elapsed() <= config.hard_timeout);
@@ -498,8 +511,8 @@ mod tests {
             ..Default::default()
         };
 
-        let mut search = Search::new(config);
-        let res = search.search(&mut board);
+        let mut search = Search::new(&config);
+        let res = search.search(&mut board, None);
         assert!(res.best_move.is_some());
         println!("{}", res.best_move.unwrap().to_long_algebraic());
     }
@@ -512,8 +525,8 @@ mod tests {
             hard_timeout: Duration::from_millis(0),
             ..Default::default()
         };
-        let mut search = Search::new(config);
-        let res = search.search(&mut board);
+        let mut search = Search::new(&config);
+        let res = search.search(&mut board, None);
         assert!(res.best_move.is_some());
         println!("{}", res.best_move.unwrap().to_long_algebraic());
     }

--- a/src/bin/byte-knight/search_thread.rs
+++ b/src/bin/byte-knight/search_thread.rs
@@ -1,0 +1,100 @@
+use std::{
+    io::Write,
+    str::FromStr,
+    sync::{
+        atomic::{self, AtomicBool, Ordering},
+        mpsc::{self, Sender},
+        Arc,
+    },
+    thread::JoinHandle,
+};
+
+use chess::{board::Board, moves::Move, pieces::SQUARE_NAME};
+use uci_parser::{UciMove, UciResponse};
+
+use crate::search::{Search, SearchParameters};
+
+fn square_index_to_uci_square(square: u8) -> uci_parser::Square {
+    uci_parser::Square::from_str(SQUARE_NAME[square as usize]).unwrap()
+}
+
+fn move_to_uci_move(mv: &Move) -> UciMove {
+    let promotion = mv.promotion_piece().map(|p| p.as_char());
+
+    match promotion {
+        Some(promotion) => UciMove {
+            src: square_index_to_uci_square(mv.from()),
+            dst: square_index_to_uci_square(mv.to()),
+            promote: Some(uci_parser::Piece::from_str(&promotion.to_string()).unwrap()),
+        },
+        None => UciMove {
+            src: square_index_to_uci_square(mv.from()),
+            dst: square_index_to_uci_square(mv.to()),
+            promote: None,
+        },
+    }
+}
+
+pub(crate) enum SearchThreadValue {
+    Params(Board, SearchParameters),
+    Exit,
+}
+
+pub(crate) struct SearchThread {
+    // ...
+    sender: Sender<SearchThreadValue>,
+    handle: Option<JoinHandle<()>>,
+    stop_search_flag: Arc<AtomicBool>,
+}
+
+impl SearchThread {
+    pub(crate) fn new() -> SearchThread {
+        let (sender, receiver) = mpsc::channel();
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        let stop_flag_clone = stop_flag.clone();
+        let handle = std::thread::spawn(move || {
+            let mut stdout = std::io::stdout();
+            loop {
+                let value = receiver.recv().unwrap();
+                match value {
+                    SearchThreadValue::Params(mut board, params) => {
+                        let flag = stop_flag.clone();
+                        let result = Search::new(&params).search(&mut board, Some(flag));
+                        let best_move = result.best_move;
+                        let move_output = UciResponse::BestMove {
+                            bestmove: best_move.map_or(None, |bot_move| {
+                                Some(move_to_uci_move(&bot_move).to_string())
+                            }),
+                            ponder: None,
+                        };
+                        writeln!(
+                            stdout,
+                            "{}",
+                            // TODO: Ponder
+                            move_output
+                        )
+                        .unwrap();
+                    }
+
+                    SearchThreadValue::Exit => {}
+                }
+            }
+        });
+        SearchThread {
+            sender,
+            handle: Some(handle),
+            stop_search_flag: stop_flag_clone,
+        }
+    }
+
+    pub(crate) fn stop_search(&self) {
+        self.stop_search_flag.store(true, Ordering::Relaxed);
+    }
+
+    pub(crate) fn start_search(&self, board: &Board, params: SearchParameters) {
+        self.stop_search_flag.store(false, Ordering::Relaxed);
+        self.sender
+            .send(SearchThreadValue::Params(board.clone(), params))
+            .unwrap();
+    }
+}

--- a/src/bin/byte-knight/search_thread.rs
+++ b/src/bin/byte-knight/search_thread.rs
@@ -1,8 +1,22 @@
+/*
+ * search_thread.rs
+ * Part of the byte-knight project
+ * Created Date: Thursday, November 21st 2024
+ * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
+ * -----
+ * Last Modified: Thu Nov 21 2024
+ * -----
+ * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
+ * GNU General Public License v3.0 or later
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * 
+ */
+
 use std::{
     io::Write,
     str::FromStr,
     sync::{
-        atomic::{self, AtomicBool, Ordering},
+        atomic::{AtomicBool, Ordering},
         mpsc::{self, Sender},
         Arc,
     },

--- a/src/bin/byte-knight/tt_table.rs
+++ b/src/bin/byte-knight/tt_table.rs
@@ -1,3 +1,17 @@
+/*
+ * tt_table.rs
+ * Part of the byte-knight project
+ * Created Date: Thursday, November 21st 2024
+ * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
+ * -----
+ * Last Modified: Thu Nov 21 2024
+ * -----
+ * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
+ * GNU General Public License v3.0 or later
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * 
+ */
+
 use chess::{board::Board, moves::Move};
 
 use crate::score::Score;

--- a/src/bin/byte-knight/worker_thread.rs
+++ b/src/bin/byte-knight/worker_thread.rs
@@ -1,3 +1,17 @@
+/*
+ * worker_thread.rs
+ * Part of the byte-knight project
+ * Created Date: Thursday, November 21st 2024
+ * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
+ * -----
+ * Last Modified: Thu Nov 21 2024
+ * -----
+ * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
+ * GNU General Public License v3.0 or later
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ */
+
 use std::{
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -9,7 +23,7 @@ use std::{
 
 /// WorkerThread is a wrapper around a thread that runs a worker function. The worker function is
 /// passed to the constructor and is executed in a loop until the worker thread is stopped.
-/// 
+///
 /// The worker function is passed an `Arc<AtomicBool>` that can be used to check if the worker
 /// thread should stop.
 ///

--- a/src/bin/byte-knight/worker_thread.rs
+++ b/src/bin/byte-knight/worker_thread.rs
@@ -1,0 +1,73 @@
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc::{self, Receiver, Sender},
+        Arc, Mutex,
+    },
+    thread::JoinHandle,
+};
+
+/// WorkerThread is a wrapper around a thread that runs a worker function. The worker function is
+/// passed to the constructor and is executed in a loop until the worker thread is stopped.
+/// 
+/// The worker function is passed an `Arc<AtomicBool>` that can be used to check if the worker
+/// thread should stop.
+///
+#[derive(Debug)]
+pub(crate) struct WorkerThread<T: Send + 'static> {
+    handle: Option<JoinHandle<()>>,
+    sender: Sender<T>,
+    receiver: Receiver<T>,
+    stop_flag: Arc<AtomicBool>,
+}
+
+impl<T: Send + 'static> WorkerThread<T> {
+    /// .
+    ///
+    /// # Panics
+    ///
+    /// Panics if .
+    pub fn new<F>(sender: Sender<T>, receiver: Receiver<T>, worker: F) -> WorkerThread<T>
+    where
+        F: Fn(Arc<AtomicBool>) + Send + 'static,
+    {
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        let stop_flag_clone = stop_flag.clone();
+        let handle = Some(std::thread::spawn(move || {
+            worker(stop_flag_clone.clone());
+        }));
+
+        WorkerThread {
+            handle,
+            sender,
+            receiver,
+            stop_flag,
+        }
+    }
+
+    pub fn send(&self, data: T) -> Result<(), mpsc::SendError<T>> {
+        self.sender.send(data)
+    }
+
+    pub fn sender(&self) -> Sender<T> {
+        self.sender.clone()
+    }
+
+    pub fn receiver(&self) -> &Receiver<T> {
+        &self.receiver
+    }
+
+    pub fn stop(&mut self) {
+        self.stop_flag.store(true, Ordering::Relaxed);
+
+        if let Some(handle) = self.handle.take() {
+            handle.join().unwrap();
+        }
+    }
+}
+
+impl<T: Send + 'static> Drop for WorkerThread<T> {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}


### PR DESCRIPTION
## Changes

- Added a dedicated search thread to run our searches on
- Restructured the engine to have a `run()` function that processes UCI commands as they come in
- Added an `InputHandler` that reads messages from `stdin` and parses them to `UciCommands` on a separate thread
- Restructured `Search` to be cancelable via an `Arc<AtomicBool>` flag
- Added a generic `WorkerThread` that manages a thread and provides a `Sender<>` `Receiver<>` pair

This seems to have greatly improved the issues I was seeing previously on OpenBench, though we did still have 2 crashes from the last SPRT run.

```
Elo   | -2.68 +- 5.69 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -3.11 (-2.94, 2.94) [0.00, 10.00]
Games | N: 3628 W: 529 L: 557 D: 2542
Penta | [43, 311, 1124, 303, 33]
https://developerpaul123.pythonanywhere.com/test/24/
```