### PR TITLE
chore: update how tt-move scoring is done.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /data/lichess_db_puzzle.csv
 **/build/*
 *.exe
+**/.DS_Store

--- a/src/bin/byte-knight/evaluation.rs
+++ b/src/bin/byte-knight/evaluation.rs
@@ -66,7 +66,7 @@ impl Evaluation {
         tt_entry: &Option<TranspositionTableEntry>,
     ) -> Score {
         if tt_entry.is_some_and(|tt| *mv == tt.board_move) {
-            return -Score::INF;
+            return Score::new(i64::MIN);
         }
         let mut score = Score::new(0);
 


### PR DESCRIPTION
## Changes

- Ensure that the tt-move gets the _best_ possible score (thanks @dannyhammer)
- Also added DS_Store files to the gitignore

bench: 1994757

```
Elo   | 0.53 +- 3.69 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -3.01 (-2.94, 2.94) [0.00, 10.00]
Games | N: 9146 W: 1514 L: 1500 D: 6132
Penta | [100, 822, 2712, 842, 97]
http://developerpaul123.pythonanywhere.com/test/26/
```