### PR TITLE
chore: update ci runner images to be explicit

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Don't use `ubuntu-latest`, instead specify the ubuntu version explicitly (fixes #24)

bench: 2577543