### PR TITLE
chore: add documentation

### DIFF
--- a/chess/src/bitboard.rs
+++ b/chess/src/bitboard.rs
@@ -56,6 +56,7 @@ impl Bitboard {
         Bitboard { data: 0 }
     }
 
+    /// Create a bitboard from the given square index.
     pub const fn from_square(square: u8) -> Self {
         Bitboard { data: 1 << square }
     }
@@ -86,6 +87,25 @@ impl Bitboard {
         self.data
     }
 
+    /// Check if the bitboard intersects with another bitboard.
+    ///
+    /// # Arguments
+    ///
+    /// - `other` - The other bitboard to check for intersection.
+    ///
+    /// # Returns
+    ///
+    /// - `bool` - True if the bitboards intersect, false otherwise.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use chess::bitboard::Bitboard;
+    ///
+    /// let bb1 = Bitboard::new(0x8000000000000001);
+    /// let bb2 = Bitboard::new(0x0000000000000001);
+    /// assert!(bb1.intersects(bb2));
+    /// ```
     pub fn intersects(&self, other: impl Into<Self>) -> bool {
         (*self & other.into()).number_of_occupied_squares() > 0
     }
@@ -103,7 +123,6 @@ impl PartialEq<u64> for Bitboard {
     }
 }
 
-// Implement bitwise operations for Bitboard
 impl BitAnd for Bitboard {
     type Output = Self;
     fn bitand(self, rhs: Self) -> Self::Output {

--- a/chess/src/bitboard.rs
+++ b/chess/src/bitboard.rs
@@ -4,7 +4,7 @@
  * Created Date: Wednesday, August 14th 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified:
+ * Last Modified: Tue Nov 26 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later

--- a/chess/src/bitboard_helpers.rs
+++ b/chess/src/bitboard_helpers.rs
@@ -1,3 +1,17 @@
+/*
+ * bitboard_helpers.rs
+ * Part of the byte-knight project
+ * Created Date: Monday, November 25th 2024
+ * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
+ * -----
+ * Last Modified: Tue Nov 26 2024
+ * -----
+ * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
+ * GNU General Public License v3.0 or later
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * 
+ */
+
 use crate::bitboard::Bitboard;
 
 /// Returns the index of the next bit set to 1 in the bitboard and sets it to 0.

--- a/chess/src/bitboard_helpers.rs
+++ b/chess/src/bitboard_helpers.rs
@@ -9,43 +9,43 @@
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
  * https://www.gnu.org/licenses/gpl-3.0-standalone.html
- * 
+ *
  */
 
 use crate::bitboard::Bitboard;
 
 /// Returns the index of the next bit set to 1 in the bitboard and sets it to 0.
-/// 
+///
 /// # Arguments
-/// 
+///
 /// * `bitboard` - The bitboard to get the next bit from.
-/// 
+///
 /// # Returns
-/// 
+///
 /// The index of the next bit set to 1 in the bitboard.
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```
 /// use chess::bitboard::Bitboard;
 /// use chess::bitboard_helpers::next_bit;
-/// 
+///
 /// let mut bb = Bitboard::new(0x8000000000000001);
 /// assert_eq!(next_bit(&mut bb), 0);
 /// assert_eq!(next_bit(&mut bb), 63);
 /// assert_eq!(bb.as_number(), 0);
-/// 
+///
 /// ```
 ///  
 /// ```
 /// use chess::bitboard::Bitboard;
 /// use chess::bitboard_helpers::next_bit;
-/// 
+///
 /// let mut bb = Bitboard::new(0xFFFFFFFFFFFFFFFF);
 /// for i in 0..64 {
 ///    assert_eq!(next_bit(&mut bb), i);
 /// }
-/// 
+///
 /// ```
 ///
 pub fn next_bit(bitboard: &mut Bitboard) -> usize {

--- a/chess/src/bitboard_helpers.rs
+++ b/chess/src/bitboard_helpers.rs
@@ -1,5 +1,39 @@
 use crate::bitboard::Bitboard;
 
+/// Returns the index of the next bit set to 1 in the bitboard and sets it to 0.
+/// 
+/// # Arguments
+/// 
+/// * `bitboard` - The bitboard to get the next bit from.
+/// 
+/// # Returns
+/// 
+/// The index of the next bit set to 1 in the bitboard.
+/// 
+/// # Examples
+/// 
+/// ```
+/// use chess::bitboard::Bitboard;
+/// use chess::bitboard_helpers::next_bit;
+/// 
+/// let mut bb = Bitboard::new(0x8000000000000001);
+/// assert_eq!(next_bit(&mut bb), 0);
+/// assert_eq!(next_bit(&mut bb), 63);
+/// assert_eq!(bb.as_number(), 0);
+/// 
+/// ```
+///  
+/// ```
+/// use chess::bitboard::Bitboard;
+/// use chess::bitboard_helpers::next_bit;
+/// 
+/// let mut bb = Bitboard::new(0xFFFFFFFFFFFFFFFF);
+/// for i in 0..64 {
+///    assert_eq!(next_bit(&mut bb), i);
+/// }
+/// 
+/// ```
+///
 pub fn next_bit(bitboard: &mut Bitboard) -> usize {
     let square = bitboard.as_number().trailing_zeros();
     *bitboard ^= 1u64 << square;

--- a/chess/src/board.rs
+++ b/chess/src/board.rs
@@ -236,7 +236,7 @@ impl Board {
     /// # Returns
     ///
     /// - a Result containing a [`Board`] if parsing was successful or
-    /// [`FenError`] if the FEN string is invalid or cannot be parsed.
+    ///   [`FenError`] if the FEN string is invalid or cannot be parsed.
     pub fn from_fen(fen: &str) -> Result<Board, FenError> {
         let mut board = Board::new();
 
@@ -615,6 +615,7 @@ mod tests {
         moves::{MoveDescriptor, MoveType},
         rank::Rank,
         side::Side,
+        square,
     };
 
     use super::*;

--- a/chess/src/board_state.rs
+++ b/chess/src/board_state.rs
@@ -9,7 +9,7 @@
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
  * https://www.gnu.org/licenses/gpl-3.0-standalone.html
- * 
+ *
  */
 
 use crate::{definitions::CastlingAvailability, moves::Move, side::Side, zobrist::ZobristHash};

--- a/chess/src/board_state.rs
+++ b/chess/src/board_state.rs
@@ -1,6 +1,11 @@
 use crate::{definitions::CastlingAvailability, moves::Move, side::Side, zobrist::ZobristHash};
 use std::fmt::Display;
 
+/// Represents the state of the board at a given point in time.
+/// This includes the half move clock, full move number, side to move,
+/// en passant square, castling rights, and the Zobrist hash.
+///
+/// This is used to restore the state in [`Board`] when un-making a move.
 #[derive(Debug, Clone, Copy)]
 pub struct BoardState {
     pub half_move_clock: u32,

--- a/chess/src/board_state.rs
+++ b/chess/src/board_state.rs
@@ -1,3 +1,17 @@
+/*
+ * board_state.rs
+ * Part of the byte-knight project
+ * Created Date: Tuesday, November 26th 2024
+ * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
+ * -----
+ * Last Modified: Tue Nov 26 2024
+ * -----
+ * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
+ * GNU General Public License v3.0 or later
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * 
+ */
+
 use crate::{definitions::CastlingAvailability, moves::Move, side::Side, zobrist::ZobristHash};
 use std::fmt::Display;
 

--- a/chess/src/color.rs
+++ b/chess/src/color.rs
@@ -9,7 +9,7 @@
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
  * https://www.gnu.org/licenses/gpl-3.0-standalone.html
- * 
+ *
  */
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/chess/src/color.rs
+++ b/chess/src/color.rs
@@ -1,3 +1,17 @@
+/*
+ * color.rs
+ * Part of the byte-knight project
+ * Created Date: Monday, November 25th 2024
+ * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
+ * -----
+ * Last Modified: Tue Nov 26 2024
+ * -----
+ * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
+ * GNU General Public License v3.0 or later
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * 
+ */
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Color {
     White,

--- a/chess/src/definitions.rs
+++ b/chess/src/definitions.rs
@@ -4,7 +4,7 @@
  * Created Date: Wednesday, August 21st 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Tue Nov 12 2024
+ * Last Modified: Tue Nov 26 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -20,6 +20,7 @@ pub const SLASH: char = '/';
 
 /// max number of moves in a game from this pos R6R/3Q4/1Q4Q1/4Q3/2Q4Q/Q4Q2/pp1Q4/kBNN1KB1 w - - 0 1
 pub const MAX_MOVE_LIST_SIZE: usize = 218;
+/// Maximum number of moves saved in the history
 pub const MAX_MOVES: usize = 3072;
 pub const MAX_MOVE_RULE: u32 = 100;
 

--- a/chess/src/fen.rs
+++ b/chess/src/fen.rs
@@ -10,6 +10,7 @@ use crate::{
     square::to_square,
 };
 
+/// Represents the 6 parts of a FEN string.
 #[derive(Debug)]
 pub enum FenPart {
     PiecePlacement = 1,
@@ -33,6 +34,7 @@ impl Display for FenPart {
     }
 }
 
+/// Represents an error that occurred while parsing a FEN string.
 #[derive(Error, Debug)]
 pub struct FenError {
     offending_parts: Option<Vec<FenPart>>,

--- a/chess/src/fen.rs
+++ b/chess/src/fen.rs
@@ -1,3 +1,17 @@
+/*
+ * fen.rs
+ * Part of the byte-knight project
+ * Created Date: Tuesday, November 26th 2024
+ * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
+ * -----
+ * Last Modified: Tue Nov 26 2024
+ * -----
+ * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
+ * GNU General Public License v3.0 or later
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * 
+ */
+
 use std::fmt::{Display, Formatter};
 
 use thiserror::Error;

--- a/chess/src/fen.rs
+++ b/chess/src/fen.rs
@@ -9,7 +9,7 @@
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
  * https://www.gnu.org/licenses/gpl-3.0-standalone.html
- * 
+ *
  */
 
 use std::fmt::{Display, Formatter};

--- a/chess/src/file.rs
+++ b/chess/src/file.rs
@@ -1,3 +1,17 @@
+/*
+ * file.rs
+ * Part of the byte-knight project
+ * Created Date: Tuesday, November 26th 2024
+ * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
+ * -----
+ * Last Modified: Tue Nov 26 2024
+ * -----
+ * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
+ * GNU General Public License v3.0 or later
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ */
+
 use anyhow::Result;
 
 /// Represents a file on the chess board.

--- a/chess/src/file.rs
+++ b/chess/src/file.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 
+/// Represents a file on the chess board.
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum File {
@@ -14,6 +15,23 @@ pub enum File {
 }
 
 impl File {
+    /// Returns the file offset by `delta` if it is within range.
+    /// Returns `None` if the resulting file is out of bounds.
+    ///
+    /// # Arguments
+    ///
+    /// - `delta`: The offset to apply to the file.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use chess::file::File;
+    ///
+    /// assert_eq!(File::A.offset(1), Some(File::B));
+    /// assert_eq!(File::A.offset(-1), None);
+    /// assert_eq!(File::H.offset(1), None);
+    /// assert_eq!(File::H.offset(-1), Some(File::G));
+    /// ```
     pub fn offset(&self, delta: i8) -> Option<Self> {
         let new_file = (*self as i8) + delta;
         if (0..=7).contains(&new_file) {
@@ -22,6 +40,7 @@ impl File {
         None
     }
 
+    /// Returns the character representation of the file (lowercase)
     pub fn to_char(&self) -> char {
         match self {
             Self::A => 'a',

--- a/chess/src/legal_move_generation.rs
+++ b/chess/src/legal_move_generation.rs
@@ -1,3 +1,17 @@
+/*
+ * legal_move_generation.rs
+ * Part of the byte-knight project
+ * Created Date: Tuesday, November 26th 2024
+ * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
+ * -----
+ * Last Modified: Tue Nov 26 2024
+ * -----
+ * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
+ * GNU General Public License v3.0 or later
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * 
+ */
+
 use crate::move_generation::NORTH;
 use crate::move_generation::RANK_BITBOARDS;
 use crate::move_generation::SOUTH;
@@ -183,6 +197,7 @@ impl MoveGenerator {
     ///
     /// # Arguments
     /// - board - The current board state
+    /// - occupancy - The occupancy bitboard
     ///
     /// # Returns
     ///

--- a/chess/src/legal_move_generation.rs
+++ b/chess/src/legal_move_generation.rs
@@ -352,8 +352,8 @@ impl MoveGenerator {
         let is_unobstructed = pushes & !occupancy == Bitboard::default();
 
         let can_double_push = match us {
-            Side::White => Board::is_square_on_rank(from_square, Rank::R2 as u8),
-            Side::Black => Board::is_square_on_rank(from_square, Rank::R7 as u8),
+            Side::White => square::is_square_on_rank(from_square, Rank::R2 as u8),
+            Side::Black => square::is_square_on_rank(from_square, Rank::R7 as u8),
             Side::Both => panic!("Both side not allowed"),
         };
 

--- a/chess/src/legal_move_generation.rs
+++ b/chess/src/legal_move_generation.rs
@@ -9,7 +9,7 @@
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
  * https://www.gnu.org/licenses/gpl-3.0-standalone.html
- * 
+ *
  */
 
 use crate::move_generation::NORTH;

--- a/chess/src/lib.rs
+++ b/chess/src/lib.rs
@@ -4,7 +4,7 @@
  * Created Date: Friday, August 16th 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified:
+ * Last Modified: Tue Nov 26 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later

--- a/chess/src/magics.rs
+++ b/chess/src/magics.rs
@@ -156,6 +156,7 @@ pub(crate) const ROOK_MAGIC_VALUES: [u64; NumberOf::SQUARES] = [
     864972604513985025,
 ];
 
+/// "Magic" number used for fancy bitboard operations.
 #[derive(Serialize, Default, Deserialize, Debug, Clone, Copy)]
 pub struct MagicNumber {
     pub relevant_bits_mask: u64,
@@ -175,8 +176,8 @@ impl MagicNumber {
     }
 
     /// Returns the index of the magic number in the table.
-    /// This is basically the same formula used to calculate magic numbers, but it's just missing the magic value.
-    /// We take into account the shift and offset to calculate the index without the magic value.
+    ///
+    /// Calculated by multiplying the blocker number with the magic number and shifting it to the right by the shift value.
     pub fn index(&self, occupancy: Bitboard) -> usize {
         let blockers = occupancy & self.relevant_bits_mask;
         // need to shift

--- a/chess/src/move_generation.rs
+++ b/chess/src/move_generation.rs
@@ -4,7 +4,7 @@
  * Created Date: Wednesday, August 28th 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Wed Nov 20 2024
+ * Last Modified: Tue Nov 26 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -807,8 +807,8 @@ impl MoveGenerator {
                 let bb_push = Bitboard::new(1u64 << to_square);
                 let bb_single_push = bb_push & empty;
                 let can_double_push = match us {
-                    Side::White => Board::is_square_on_rank(from_square, Rank::R2 as u8),
-                    Side::Black => Board::is_square_on_rank(from_square, Rank::R7 as u8),
+                    Side::White => square::is_square_on_rank(from_square, Rank::R2 as u8),
+                    Side::Black => square::is_square_on_rank(from_square, Rank::R7 as u8),
                     Side::Both => panic!("Both side not allowed"),
                 };
 
@@ -917,7 +917,7 @@ impl MoveGenerator {
             let is_double_move = piece == Piece::Pawn
                 && (to_square as i8 - from.to_square_index() as i8).abs() == 16;
             let is_promotion =
-                piece == Piece::Pawn && Board::is_square_on_rank(to_square, promotion_rank as u8);
+                piece == Piece::Pawn && square::is_square_on_rank(to_square, promotion_rank as u8);
 
             if is_double_move && en_passant {
                 panic!("Double move and en passant should not happen");

--- a/chess/src/move_generation.rs
+++ b/chess/src/move_generation.rs
@@ -171,6 +171,7 @@ fn initialize_rays_between(rays_between: &mut [[Bitboard; NumberOf::SQUARES]; Nu
     }
 }
 
+/// The MoveGenerator struct is responsible for generating moves for a given board state.
 pub struct MoveGenerator {
     pub(crate) king_attacks: [Bitboard; NumberOf::SQUARES],
     pub(crate) knight_attacks: [Bitboard; NumberOf::SQUARES],
@@ -408,6 +409,18 @@ impl MoveGenerator {
         attacks
     }
 
+    /// Calculate the "relevant" bits for rook attacks at a given square.
+    ///
+    /// The relevant bits are the squares that the rook can attack from a given square.
+    /// The returned bitboard does not include edges.
+    ///
+    /// # Arguments
+    ///
+    /// - square - The square to calculate the relevant bits for.
+    ///
+    /// # Returns
+    ///
+    /// A bitboard representing the relevant bits for the rook attacks at the given square.
     pub fn relevant_rook_bits(square: u8) -> Bitboard {
         let mut bb = Bitboard::default();
         bb.set_square(square);
@@ -421,6 +434,18 @@ impl MoveGenerator {
         rook_rays_bb & !edges & !bb
     }
 
+    /// Calculate the "relevant" bits for bishop attacks at a given square.
+    ///
+    /// The relevant bits are the squares that the bishop can attack from a given square.
+    /// The returned bitboard does not include edges.
+    ///
+    /// # Arguments
+    ///
+    /// - square - The square to calculate the relevant bits for.
+    ///
+    /// # Returns
+    ///
+    /// A bitboard representing the relevant bits for the bishop attacks at the given square.
     pub fn relevant_bishop_bits(square: u8) -> Bitboard {
         let mut bb = Bitboard::default();
         bb.set_square(square);
@@ -434,6 +459,15 @@ impl MoveGenerator {
         bishop_ray_attacks & !edges & !bb
     }
 
+    /// Generate all possible blocker permutations for a given bitboard.
+    ///
+    /// # Arguments
+    ///
+    /// - bb - The bitboard to generate the blocker permutations for.
+    ///
+    /// # Returns
+    ///
+    /// A vector of bitboards representing all possible blocker permutations for the given bitboard.
     pub fn create_blocker_permutations(bb: Bitboard) -> Vec<Bitboard> {
         // use the carry-rippler method to cycle through all possible permutations of the given bitboard
         let mask = bb;
@@ -472,11 +506,31 @@ impl MoveGenerator {
         attacks
     }
 
+    /// Calculates rook attacks from a given square with a given blocker bitboard.
+    ///
+    /// # Arguments
+    ///
+    /// - square - The square to calculate the attacks from
+    /// - blocker - The blocker bitboard
+    ///
+    /// # Returns
+    ///
+    /// A bitboard representing the rook attacks from the given square with the given blocker bitboard.
     pub fn calculate_rook_attack(square: u8, blocker: &Bitboard) -> Bitboard {
         // calculate ray attacks for the rook from its square
         MoveGenerator::orthogonal_ray_attacks(square, blocker.as_number())
     }
 
+    /// Calculates bishop attacks from a given square with a given blocker bitboard.
+    ///
+    /// # Arguments
+    ///
+    /// - square - The square to calculate the attacks from
+    /// - blocker - The blocker bitboard
+    ///
+    /// # Returns
+    ///
+    /// A vector of bitboards representing the bishop attacks from the given square with the given blocker bitboard.
     pub fn bishop_attacks(square: u8, blockers: &Vec<Bitboard>) -> Vec<Bitboard> {
         let mut attacks = Vec::with_capacity(blockers.len());
         for blocker in blockers {
@@ -485,10 +539,21 @@ impl MoveGenerator {
         attacks
     }
 
+    /// Calculates bishop attacks from a given square with a given blocker bitboard.
+    ///
+    /// # Arguments
+    ///
+    /// - square - The square to calculate the attacks from
+    /// - blocker - The blocker bitboard
+    ///
+    /// # Returns
+    ///
+    /// A bitboard representing the bishop attacks from the given square with the given blocker bitboard.
     pub fn calculate_bishop_attack(square: u8, blocker: &Bitboard) -> Bitboard {
         MoveGenerator::diagonal_ray_attacks(square, blocker.as_number())
     }
 
+    /// Calculate the ray between two squares. This is simply a look up as we pre-calculate all rays between all squares.
     pub(crate) fn ray_between(&self, from: Square, to: Square) -> Bitboard {
         self.rays_between[from.to_square_index() as usize][to.to_square_index() as usize]
     }
@@ -544,6 +609,14 @@ impl MoveGenerator {
         attacks
     }
 
+    /// Get attacks for a given piece.
+    ///
+    /// # Arguments
+    ///
+    /// - piece - The piece to get the attacks for
+    /// - square - The square the piece is on
+    /// - attacking_side - The side that is attacking
+    /// - occupancy - The current occupancy of the board
     pub(crate) fn get_piece_attacks(
         &self,
         piece: Piece,
@@ -885,6 +958,15 @@ impl MoveGenerator {
         }
     }
 
+    /// Enumerate all moves in a given bitboard and add them to the given [`MoveList`]
+    ///
+    /// # Arguments
+    ///
+    /// - bitboard - The bitboard to enumerate moves for
+    /// - from - The square the piece is moving from
+    /// - piece - The piece that is moving
+    /// - board - The current board state
+    /// - move_list - The list of moves to append to
     pub(crate) fn enumerate_moves(
         &self,
         bitboard: &Bitboard,

--- a/chess/src/move_history.rs
+++ b/chess/src/move_history.rs
@@ -9,7 +9,7 @@
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
  * https://www.gnu.org/licenses/gpl-3.0-standalone.html
- * 
+ *
  */
 
 use crate::{board_state::BoardState, definitions::MAX_MOVES};

--- a/chess/src/move_history.rs
+++ b/chess/src/move_history.rs
@@ -1,5 +1,20 @@
+/*
+ * move_history.rs
+ * Part of the byte-knight project
+ * Created Date: Monday, November 25th 2024
+ * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
+ * -----
+ * Last Modified: Tue Nov 26 2024
+ * -----
+ * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
+ * GNU General Public License v3.0 or later
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * 
+ */
+
 use crate::{board_state::BoardState, definitions::MAX_MOVES};
 
+/// A struct that holds the history of the board states
 pub(crate) struct BoardHistory {
     board_states: Vec<BoardState>,
 }
@@ -19,14 +34,17 @@ impl BoardHistory {
         }
     }
 
+    /// Push a board state to the history list
     pub fn push(&mut self, board_state: BoardState) {
         self.board_states.push(board_state);
     }
 
+    /// Pop a board state from the history list
     pub fn pop(&mut self) -> Option<BoardState> {
         self.board_states.pop()
     }
 
+    /// Get an iterator to the board history
     pub fn iter(&self) -> std::slice::Iter<BoardState> {
         self.board_states.iter()
     }

--- a/chess/src/move_list.rs
+++ b/chess/src/move_list.rs
@@ -1,7 +1,23 @@
+/*
+ * move_list.rs
+ * Part of the byte-knight project
+ * Created Date: Monday, November 25th 2024
+ * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
+ * -----
+ * Last Modified: Tue Nov 26 2024
+ * -----
+ * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
+ * GNU General Public License v3.0 or later
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * 
+ */
+
 use arrayvec::ArrayVec;
 
 use crate::{definitions::MAX_MOVE_LIST_SIZE, moves::Move};
 
+/// A list of moves used in move generation. This is a fixed-size list that can hold up to 218 moves.
+/// If more moves are added, the program will panic.
 pub struct MoveList {
     moves: ArrayVec<Move, MAX_MOVE_LIST_SIZE>,
 }
@@ -13,20 +29,27 @@ impl Default for MoveList {
 }
 
 impl MoveList {
+    /// Create a new [MoveList] with a capacity of 218 moves.
+    /// Note that no default assignment is done for the moves in the list.
+    /// The intention is for the items in the [`MoveList`] to be overwritten.
     pub fn new() -> Self {
         MoveList {
             moves: ArrayVec::new(),
         }
     }
 
+    /// Returns the number of moves in the list.
     pub fn len(&self) -> usize {
         self.moves.len()
     }
 
+    /// Returns true if the list is empty.
     pub fn is_empty(&self) -> bool {
         self.moves.is_empty()
     }
 
+    /// Push a move to the list. If the list is full, the program will panic.
+    /// This is done to avoid the overhead of returning a Result.
     pub fn push(&mut self, mv: Move) {
         let overflow = self.moves.try_push(mv);
         if overflow.is_err() {
@@ -34,14 +57,17 @@ impl MoveList {
         }
     }
 
+    /// Get an iterator to the moves in the list.
     pub fn iter(&self) -> impl Iterator<Item = &Move> {
         self.moves.iter()
     }
 
+    /// Get the move at the given index. Returns None if the index is out of bounds.
     pub fn at(&self, index: usize) -> Option<&Move> {
         self.moves.get(index)
     }
 
+    /// Clear the list of moves.
     pub fn clear(&mut self) {
         self.moves.clear();
     }

--- a/chess/src/move_list.rs
+++ b/chess/src/move_list.rs
@@ -9,7 +9,7 @@
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
  * https://www.gnu.org/licenses/gpl-3.0-standalone.html
- * 
+ *
  */
 
 use arrayvec::ArrayVec;

--- a/chess/src/move_making.rs
+++ b/chess/src/move_making.rs
@@ -4,7 +4,7 @@
  * Created Date: Friday, August 23rd 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Wed Nov 20 2024
+ * Last Modified: Tue Nov 26 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -20,7 +20,7 @@ use crate::{
     pieces::{Piece, SQUARE_NAME},
     rank::Rank,
     side::Side,
-    square::Square,
+    square::{self, Square},
 };
 use anyhow::{bail, Result};
 
@@ -67,7 +67,7 @@ impl Board {
         // now just figure out the move descriptor
         // need to check if the move is a castle, en passant, promotion or a pawn two up move
         let can_double_push = piece == Piece::Pawn
-            && Board::is_square_on_rank(
+            && square::is_square_on_rank(
                 from.to_square_index(),
                 Rank::pawn_start_rank(side).as_number(),
             );

--- a/chess/src/moves.rs
+++ b/chess/src/moves.rs
@@ -75,8 +75,8 @@ pub enum MoveType {
 }
 
 /// Compact, 32-bit move representation
-/// Taken from https://github.com/SebLague/Chess-Challenge/blob/main/Chess-Challenge/src/Framework/Chess/Board/Move.cs
-/// Also inspired by Rustic's move representation: https://github.com/mvanthoor/rustic/blob/master/src/movegen/defs.rs
+/// Taken from <https://github.com/SebLague/Chess-Challenge/blob/main/Chess-Challenge/src/Framework/Chess/Board/Move.cs>
+/// Also inspired by Rustic's move representation: <https://github.com/mvanthoor/rustic/blob/master/src/movegen/defs.rs>
 #[derive(Default, Debug, Clone, Copy)]
 pub struct Move {
     /// The move information, from LSB to MSB:

--- a/chess/src/perft.rs
+++ b/chess/src/perft.rs
@@ -9,7 +9,7 @@
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
  * https://www.gnu.org/licenses/gpl-3.0-standalone.html
- * 
+ *
  */
 
 use crate::{board::Board, move_generation::MoveGenerator, move_list::MoveList, moves::Move};

--- a/chess/src/perft.rs
+++ b/chess/src/perft.rs
@@ -1,3 +1,17 @@
+/*
+ * perft.rs
+ * Part of the byte-knight project
+ * Created Date: Monday, November 25th 2024
+ * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
+ * -----
+ * Last Modified: Tue Nov 26 2024
+ * -----
+ * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
+ * GNU General Public License v3.0 or later
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * 
+ */
+
 use crate::{board::Board, move_generation::MoveGenerator, move_list::MoveList, moves::Move};
 use anyhow::{bail, Result};
 
@@ -6,6 +20,18 @@ pub struct SplitPerftResult {
     pub nodes: u64,
 }
 
+/// Perform split perft on the given board with the given move generator and depth.
+///
+/// # Arguments
+///
+/// - `board` - The board to perform perft on.
+/// - `move_gen` - The move generator to use.
+/// - `depth` - The depth to perform perft to.
+/// - `print_moves` - If true, extra debug information will be printed.
+///
+/// # Returns
+///
+/// A vector of `SplitPerftResult` containing the move and the number of nodes at that move.
 #[cfg_attr(not(debug_assertions), inline(always))]
 #[cfg_attr(debug_assertions, inline(never))]
 pub fn split_perft(
@@ -49,6 +75,7 @@ pub fn split_perft(
     Ok(results)
 }
 
+/// Perform perft on the given board with the given move generator and depth.
 #[cfg_attr(not(debug_assertions), inline(always))]
 #[cfg_attr(debug_assertions, inline(never))]
 pub fn perft(

--- a/chess/src/pieces.rs
+++ b/chess/src/pieces.rs
@@ -9,7 +9,7 @@
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
  * https://www.gnu.org/licenses/gpl-3.0-standalone.html
- * 
+ *
  */
 
 use std::fmt::Display;

--- a/chess/src/pieces.rs
+++ b/chess/src/pieces.rs
@@ -1,3 +1,17 @@
+/*
+ * pieces.rs
+ * Part of the byte-knight project
+ * Created Date: Monday, November 25th 2024
+ * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
+ * -----
+ * Last Modified: Tue Nov 26 2024
+ * -----
+ * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
+ * GNU General Public License v3.0 or later
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * 
+ */
+
 use std::fmt::Display;
 
 use crate::definitions::NumberOf;
@@ -112,6 +126,7 @@ impl Piece {
         self.is_rook() || self.is_bishop() || self.is_queen()
     }
 
+    /// Returns the short name of the piece as a lowercase character.
     pub fn as_char(&self) -> char {
         PIECE_SHORT_NAMES[*self as usize].to_ascii_lowercase()
     }

--- a/chess/src/rank.rs
+++ b/chess/src/rank.rs
@@ -9,7 +9,7 @@
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
  * https://www.gnu.org/licenses/gpl-3.0-standalone.html
- * 
+ *
  */
 
 use crate::side::Side;

--- a/chess/src/rank.rs
+++ b/chess/src/rank.rs
@@ -1,6 +1,21 @@
+/*
+ * rank.rs
+ * Part of the byte-knight project
+ * Created Date: Monday, November 25th 2024
+ * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
+ * -----
+ * Last Modified: Tue Nov 26 2024
+ * -----
+ * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
+ * GNU General Public License v3.0 or later
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * 
+ */
+
 use crate::side::Side;
 use anyhow::Result;
 
+/// Represents a rank on the chess board.
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Rank {
@@ -15,7 +30,8 @@ pub enum Rank {
 }
 
 impl Rank {
-    pub fn promotion_rank(side: Side) -> Rank {
+    /// Returns the rank of the promotion square for the given side.
+    pub const fn promotion_rank(side: Side) -> Rank {
         match side {
             Side::White => Rank::R8,
             Side::Black => Rank::R1,
@@ -23,7 +39,8 @@ impl Rank {
         }
     }
 
-    pub fn pawn_start_rank(side: Side) -> Rank {
+    /// Returns the starting rank for pawns of a given side.
+    pub const fn pawn_start_rank(side: Side) -> Rank {
         match side {
             Side::White => Rank::R2,
             Side::Black => Rank::R7,
@@ -31,10 +48,26 @@ impl Rank {
         }
     }
 
+    /// Returns the rank as a number.
     pub fn as_number(&self) -> u8 {
         *self as u8
     }
 
+    /// Offset the rank by the given delta.
+    ///
+    /// Returns `None` if the resulting rank is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use chess::rank::Rank;
+    ///
+    /// assert_eq!(Rank::R1.offset(1), Some(Rank::R2));
+    /// assert_eq!(Rank::R1.offset(-1), None);
+    /// assert_eq!(Rank::R8.offset(1), None);
+    /// assert_eq!(Rank::R8.offset(-1), Some(Rank::R7));
+    /// ```
+    ///
     pub fn offset(&self, delta: i8) -> Option<Self> {
         let new_rank = (*self as i8) + delta;
         if (0..=7).contains(&new_rank) {

--- a/chess/src/side.rs
+++ b/chess/src/side.rs
@@ -9,7 +9,7 @@
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
  * https://www.gnu.org/licenses/gpl-3.0-standalone.html
- * 
+ *
  */
 
 /// Represents a side to play in chess.

--- a/chess/src/side.rs
+++ b/chess/src/side.rs
@@ -1,3 +1,18 @@
+/*
+ * side.rs
+ * Part of the byte-knight project
+ * Created Date: Monday, November 25th 2024
+ * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
+ * -----
+ * Last Modified: Tue Nov 26 2024
+ * -----
+ * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
+ * GNU General Public License v3.0 or later
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * 
+ */
+
+/// Represents a side to play in chess.
 #[repr(usize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Side {
@@ -6,9 +21,8 @@ pub enum Side {
     Both = 2,
 }
 
-impl Side {}
-
 impl Side {
+    /// Returns the opposite side.
     pub fn opposite(side: Side) -> Side {
         match side {
             Side::White => Side::Black,
@@ -17,25 +31,25 @@ impl Side {
         }
     }
 
-    /// Returns `true` if the side is [`WHITE`].
+    /// Returns `true` if the side is [`White`].
     ///
-    /// [`WHITE`]: Side::WHITE
+    /// [`White`]: Side::White
     #[must_use]
     pub fn is_white(&self) -> bool {
         matches!(self, Self::White)
     }
 
-    /// Returns `true` if the side is [`BLACK`].
+    /// Returns `true` if the side is [`Black`].
     ///
-    /// [`BLACK`]: Side::BLACK
+    /// [`Black`]: Side::Black
     #[must_use]
     pub fn is_black(&self) -> bool {
         matches!(self, Self::Black)
     }
 
-    /// Returns `true` if the side is [`BOTH`].
+    /// Returns `true` if the side is [`Both`].
     ///
-    /// [`BOTH`]: Side::BOTH
+    /// [`Both`]: Side::Both
     #[must_use]
     pub fn is_both(&self) -> bool {
         matches!(self, Self::Both)

--- a/chess/src/square.rs
+++ b/chess/src/square.rs
@@ -4,7 +4,7 @@
  * Created Date: Friday, August 16th 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Thu Nov 21 2024
+ * Last Modified: Tue Nov 26 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -144,9 +144,22 @@ pub const fn from_square(square: u8) -> (u8, u8) {
     (file, rank)
 }
 
+/// Checks if a given square is on a given rank.
+pub const fn is_square_on_rank(square: u8, rank: u8) -> bool {
+    let (_, rnk) = from_square(square);
+    rnk == rank
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::{file::File, rank::Rank, square::Square};
+    use crate::{definitions::Squares, file::File, rank::Rank, square::{is_square_on_rank, Square}};
+
+    #[test]
+    fn check_square_on_rank() {
+        assert!(is_square_on_rank(Squares::A1, Rank::R1 as u8));
+        assert!(!is_square_on_rank(Squares::A1, Rank::R2 as u8));
+        assert!(is_square_on_rank(Squares::C5, Rank::R5 as u8));
+    }
 
     #[test]
     fn parse_square_from_uci_str() {

--- a/chess/src/zobrist.rs
+++ b/chess/src/zobrist.rs
@@ -1,8 +1,23 @@
+/*
+ * zobrist.rs
+ * Part of the byte-knight project
+ * Created Date: Monday, November 25th 2024
+ * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
+ * -----
+ * Last Modified: Tue Nov 26 2024
+ * -----
+ * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
+ * GNU General Public License v3.0 or later
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * 
+ */
+
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 
 use crate::definitions::NumberOf;
 
+/// A Zobrist hash value.
 pub type ZobristHash = u64;
 
 pub struct ZobristRandomValues {
@@ -71,14 +86,17 @@ impl ZobristRandomValues {
         random_values
     }
 
+    /// Returns the Zobrist hash value for the given piece, side, and square.
     pub fn get_piece_value(&self, piece: usize, side: usize, square: usize) -> u64 {
         self.piece_values[side][piece][square]
     }
 
+    /// Returns the Zobrist hash value for the given castling option.
     pub fn get_castling_value(&self, castling: usize) -> u64 {
         self.castling_values[castling]
     }
 
+    /// Returns the Zobrist hash value for the given en passant square.
     pub fn get_en_passant_value(&self, square: Option<u8>) -> u64 {
         match square {
             None => self.en_passant_values[NumberOf::SQUARES],
@@ -86,6 +104,7 @@ impl ZobristRandomValues {
         }
     }
 
+    /// Returns the Zobrist hash value for the given side.
     pub fn get_side_value(&self, side: usize) -> u64 {
         self.side_values[side]
     }

--- a/chess/src/zobrist.rs
+++ b/chess/src/zobrist.rs
@@ -9,7 +9,7 @@
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
  * https://www.gnu.org/licenses/gpl-3.0-standalone.html
- * 
+ *
  */
 
 use rand::rngs::StdRng;

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -4,7 +4,7 @@
  * Created Date: Friday, November 15th 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Thu Nov 21 2024
+ * Last Modified: Tue Nov 26 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -34,6 +34,7 @@ impl ByteKnight {
         }
     }
 
+    /// Run the engine loop. This will block until the engine is told to quit by the input handler.
     pub fn run(&mut self) -> anyhow::Result<()> {
         println!("{}", About::BANNER);
         println!(

--- a/engine/src/input_handler.rs
+++ b/engine/src/input_handler.rs
@@ -4,7 +4,7 @@
  * Created Date: Monday, November 18th 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Thu Nov 21 2024
+ * Last Modified: Tue Nov 26 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -77,6 +77,7 @@ impl InputHandler {
         }
     }
 
+    /// Stops the worker thread. This method blocks until the worker thread has stopped.
     pub fn stop(&mut self) {
         self.stop_flag.store(true, Ordering::Relaxed);
 
@@ -89,8 +90,7 @@ impl InputHandler {
         &self.receiver
     }
 
-    /// Signal to the worker thread that it should stop. This method does not block the calling
-    /// thread.
+    /// Signal to the worker thread that it should stop.
     pub(crate) fn exit(&mut self) {
         self.stop();
     }

--- a/engine/src/psqt.rs
+++ b/engine/src/psqt.rs
@@ -4,7 +4,7 @@
  * Created Date: Thursday, November 21st 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Thu Nov 21 2024
+ * Last Modified: Tue Nov 26 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -197,6 +197,7 @@ const EG_PESTO_TABLE: [&[i64; 64]; 6] = [
 /// King, Queen, Rook, Bishop, Knight, Pawn
 const GAMEPHASE_INC: [i64; 6] = [0, 4, 2, 1, 1, 0];
 
+/// Piece-Square Tables (PST) for evaluation
 pub(crate) struct Psqt {
     mg_table: [[i64; 64]; 12],
     eg_table: [[i64; 64]; 12],
@@ -205,6 +206,7 @@ pub(crate) struct Psqt {
 const FLIP: fn(usize) -> usize = |sq| sq ^ 56;
 
 impl Psqt {
+    /// Creates a new [`Psqt`] instance and initializes the piece-square tables.
     pub(crate) fn new() -> Self {
         let mut psqt = Psqt {
             mg_table: [[0; 64]; 12],
@@ -214,6 +216,18 @@ impl Psqt {
         psqt
     }
 
+    /// Evaluates the given [`Board`] position. This uses the piece square tables
+    /// as well as a tapering function to take into account game phase.
+    ///
+    /// See <https://www.chessprogramming.org/PeSTO%27s_Evaluation_Function> for more information.
+    ///
+    /// # Arguments
+    ///
+    /// - `board`: The [`Board`] to evaluate.
+    ///
+    /// # Returns
+    ///
+    /// The score of the position.
     pub(crate) fn evaluate(&self, board: &Board) -> Score {
         let side_to_move = board.side_to_move();
         let mut mg = [0; 2];
@@ -242,6 +256,8 @@ impl Psqt {
         Score::new((mg_score * mg_phase + eg_score * eg_phase) / 24)
     }
 
+    /// Helper to initialize the tables
+    /// See <https://www.chessprogramming.org/PeSTO%27s_Evaluation_Function>
     fn initialize_tables(&mut self) {
         for (p, pc) in (0..6).zip((0..12).step_by(2)) {
             for sq in 0..64 {

--- a/engine/src/score.rs
+++ b/engine/src/score.rs
@@ -4,7 +4,7 @@
  * Created Date: Thursday, November 14th 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Thu Nov 21 2024
+ * Last Modified: Tue Nov 26 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -19,12 +19,14 @@ use std::{
 
 use uci_parser::UciScore;
 
+/// Represents a score in centipawns.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Score(pub i64);
 
 impl Score {
     pub const DRAW: Score = Score(0);
     pub const MATE: Score = Score(10_000);
+    /// We use i32 so we don't overflow
     pub const INF: Score = Score(i32::MAX as i64);
 
     pub fn new(score: i64) -> Score {

--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -4,7 +4,7 @@
  * Created Date: Thursday, November 21st 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Thu Nov 21 2024
+ * Last Modified: Tue Nov 26 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -33,6 +33,7 @@ use crate::{
 
 const MAX_DEPTH: u8 = 128;
 
+/// Result for a search.
 #[derive(Clone, Copy, Debug)]
 pub struct SearchResult {
     pub score: Score,
@@ -67,6 +68,7 @@ impl Display for SearchResult {
     }
 }
 
+/// Input parameters for the search.
 #[derive(Clone, Debug)]
 pub struct SearchParameters {
     pub max_depth: u8,
@@ -89,6 +91,7 @@ impl Default for SearchParameters {
 }
 
 impl SearchParameters {
+    /// Creates a new set of search parameters from the UCI options and the current board.
     pub fn new(uci_options: &UciSearchOptions, board: &Board) -> Self {
         let mut params = Self::default();
         if let Some(depth) = uci_options.depth {
@@ -159,6 +162,17 @@ impl Search {
         }
     }
 
+    /// Search for the best move in the given board state. This will output
+    /// UCI info lines as it searches.
+    ///
+    /// # Arguments
+    ///
+    /// - `board` - The current board state.
+    /// - `stop_flag` - An optional flag to stop the search.
+    ///
+    /// # Returns
+    ///
+    /// The best move found.
     pub fn search(
         &mut self,
         board: &mut Board,

--- a/engine/src/search_thread.rs
+++ b/engine/src/search_thread.rs
@@ -4,7 +4,7 @@
  * Created Date: Thursday, November 21st 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Thu Nov 21 2024
+ * Last Modified: Tue Nov 26 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -55,6 +55,8 @@ pub(crate) enum SearchThreadValue {
     Exit,
 }
 
+/// A thread worker that manages the search. It receives search parameters and a board state and
+/// sends the best move to the UCI output.
 pub(crate) struct SearchThread {
     sender: Sender<SearchThreadValue>,
     handle: Option<JoinHandle<()>>,
@@ -62,6 +64,8 @@ pub(crate) struct SearchThread {
 }
 
 impl SearchThread {
+    /// Creates a new [`SearchThread`]. The search thread is responsible for managing the search.
+    /// When the search thread is created, the thread loop starts and begins to wait for search parameters.
     pub(crate) fn new() -> SearchThread {
         let (sender, receiver) = mpsc::channel();
         let stop_flag = Arc::new(AtomicBool::new(false));
@@ -102,15 +106,19 @@ impl SearchThread {
         }
     }
 
+    /// Exits the search thread. This will stop the search thread and join it.
     pub(crate) fn exit(&mut self) {
         self.stop_search();
         self.sender.send(SearchThreadValue::Exit).unwrap();
         self.handle.take().unwrap().join().unwrap();
     }
+
+    /// Stops the current search if any is in progress.
     pub(crate) fn stop_search(&self) {
         self.stop_search_flag.store(true, Ordering::Relaxed);
     }
 
+    /// Starts a new search with the given parameters and board state.
     pub(crate) fn start_search(&self, board: &Board, params: SearchParameters) {
         self.stop_search_flag.store(false, Ordering::Relaxed);
         self.sender

--- a/engine/src/tt_table.rs
+++ b/engine/src/tt_table.rs
@@ -4,7 +4,7 @@
  * Created Date: Thursday, November 21st 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Thu Nov 21 2024
+ * Last Modified: Tue Nov 26 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -25,6 +25,7 @@ pub enum EntryFlag {
     UpperBound,
 }
 
+/// A transposition table entry.
 #[derive(Clone, Copy)]
 pub(crate) struct TranspositionTableEntry {
     pub zobrist: u64,
@@ -52,6 +53,7 @@ impl TranspositionTableEntry {
     }
 }
 
+/// A transposition table used to store the results of previous searches.
 pub(crate) struct TranspositionTable {
     table: Vec<Option<TranspositionTableEntry>>,
 }


### PR DESCRIPTION
Flush out docs for `chess` and `engine` crates.

Resolves #26 