### PR TITLE
fix: store tt table per game, not per search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,7 @@ dependencies = [
  "anyhow",
  "chess",
  "itertools",
+ "thiserror 2.0.3",
  "uci-parser",
 ]
 

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -13,3 +13,4 @@ uci-parser = { version = "0.2.0", features = [
     "parse-position-kiwipete",
     "types",
 ] }
+thiserror = "2.0.3"

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -32,6 +32,7 @@ pub struct ByteKnight {
     input_handler: InputHandler,
     search_thread: SearchThread,
     transposition_table: Arc<Mutex<TranspositionTable<true>>>,
+    debug: bool,
 }
 
 impl ByteKnight {
@@ -40,6 +41,7 @@ impl ByteKnight {
             input_handler: InputHandler::new(),
             search_thread: SearchThread::new(),
             transposition_table: Default::default(),
+            debug: false,
         }
     }
 
@@ -66,6 +68,9 @@ impl ByteKnight {
 
             match command {
                 CommandProxy::Uci(uci_command) => match uci_command {
+                    UciCommand::Debug(debug) => {
+                        self.debug = *debug;
+                    }
                     UciCommand::Quit => {
                         // clean up
                         self.search_thread.exit();

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -4,7 +4,7 @@
  * Created Date: Friday, November 15th 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Thu Nov 28 2024
+ * Last Modified: Fri Nov 29 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -21,13 +21,17 @@ use chess::board::Board;
 use uci_parser::{UciCommand, UciInfo, UciOption, UciResponse};
 
 use crate::{
-    defs::About, input_handler::InputHandler, search::SearchParameters,
-    search_thread::SearchThread, tt_table::TranspositionTable,
+    defs::About,
+    input_handler::{CommandProxy, EngineCommand, InputHandler},
+    search::SearchParameters,
+    search_thread::SearchThread,
+    tt_table::{self, TranspositionTable},
 };
 
 pub struct ByteKnight {
     input_handler: InputHandler,
     search_thread: SearchThread,
+    transposition_table: Arc<Mutex<TranspositionTable<true>>>,
 }
 
 impl ByteKnight {
@@ -35,6 +39,13 @@ impl ByteKnight {
         ByteKnight {
             input_handler: InputHandler::new(),
             search_thread: SearchThread::new(),
+            transposition_table: Default::default(),
+        }
+    }
+
+    fn clear_hash_tables(&mut self) {
+        if let Ok(tt) = self.transposition_table.lock().as_mut() {
+            tt.clear();
         }
     }
 
@@ -50,75 +61,121 @@ impl ByteKnight {
         );
         let stdout: io::Stdout = io::stdout();
         let mut board = Board::default_board();
-        let tt: Arc<Mutex<TranspositionTable>> = Arc::default();
         'engine_loop: while let Ok(command) = &self.input_handler.receiver().recv() {
             let mut stdout = stdout.lock();
+
             match command {
-                UciCommand::Quit => {
-                    // clean up
-                    self.search_thread.exit();
-                    self.input_handler.exit();
-                    break 'engine_loop;
-                }
-                UciCommand::IsReady => {
-                    writeln!(stdout, "{}", UciResponse::<String>::ReadyOk).unwrap();
-                }
-                UciCommand::Uci => {
-                    let id = UciResponse::Id {
-                        name: About::NAME,
-                        author: About::AUTHORS,
-                    };
+                CommandProxy::Uci(uci_command) => match uci_command {
+                    UciCommand::Quit => {
+                        // clean up
+                        self.search_thread.exit();
+                        self.input_handler.exit();
+                        break 'engine_loop;
+                    }
+                    UciCommand::IsReady => {
+                        writeln!(stdout, "{}", UciResponse::<String>::ReadyOk).unwrap();
+                    }
+                    UciCommand::Uci => {
+                        let id = UciResponse::Id {
+                            name: About::NAME,
+                            author: About::AUTHORS,
+                        };
 
-                    let options = vec![
-                        UciOption::spin("Hash", 16, 1, 1024),
-                        UciOption::spin("Threads", 1, 1, 1),
-                    ];
-                    // TODO: Actually implement the hash option
-                    for option in options {
-                        writeln!(stdout, "{}", UciResponse::Option(option)).unwrap();
-                    }
-                    writeln!(stdout, "{}", id).unwrap();
-                    writeln!(stdout, "{}", UciResponse::<String>::UciOk).unwrap();
-                }
-                UciCommand::UciNewGame => {
-                    board = Board::default_board();
-                    if let Ok(tt) = tt.lock().as_mut() {
-                        tt.clear();
-                    }
-                }
-                UciCommand::Position { fen, moves } => {
-                    match fen {
-                        None => {
-                            board = Board::default_board();
+                        let options = vec![
+                            UciOption::spin("Hash", 16, 1, 1024),
+                            UciOption::spin("Threads", 1, 1, 1),
+                        ];
+                        // TODO: Actually implement the hash option
+                        for option in options {
+                            writeln!(stdout, "{}", UciResponse::Option(option)).unwrap();
                         }
-                        Some(fen) => {
-                            board = Board::from_fen(fen.as_str()).unwrap();
-                        }
+                        writeln!(stdout, "{}", id).unwrap();
+                        writeln!(stdout, "{}", UciResponse::<String>::UciOk).unwrap();
                     }
+                    UciCommand::UciNewGame => {
+                        board = Board::default_board();
+                        self.clear_hash_tables();
+                    }
+                    UciCommand::Position { fen, moves } => {
+                        match fen {
+                            None => {
+                                board = Board::default_board();
+                            }
+                            Some(fen) => {
+                                board = Board::from_fen(fen.as_str()).unwrap();
+                            }
+                        }
 
-                    for mv in moves {
-                        board.make_uci_move(&mv.to_string()).unwrap();
+                        for mv in moves {
+                            board.make_uci_move(&mv.to_string()).unwrap();
+                        }
                     }
-                }
-                UciCommand::Go(search_options) => {
-                    if self.search_thread.is_searching() {
-                        eprintln!("Attempting to start a search while already searching");
+                    UciCommand::Go(search_options) => {
+                        if self.search_thread.is_searching() {
+                            eprintln!("Attempting to start a search while already searching");
+                            self.search_thread.stop_search();
+                        }
+
+                        let info =
+                            UciInfo::default().string(format!("searching {}", board.to_fen()));
+                        writeln!(stdout, "{}", UciResponse::info(info)).unwrap();
+
+                        // create the search parameters
+                        let search_params = SearchParameters::new(search_options, &board);
+                        // send them and the current board to the search thread
+                        self.search_thread.start_search(
+                            &board,
+                            search_params,
+                            self.transposition_table.clone(),
+                        );
+                    }
+                    UciCommand::SetOption { name, value } => {
+                        if name.to_lowercase() == "hash" {
+                            if let Some(val) = value {
+                                // set the hash size, making sure it is within the bounds we have set.
+                                if let Ok(hash_size) = val.parse::<usize>() {
+                                    if hash_size < tt_table::MIN_TABLE_SIZE_MB {
+                                        eprintln!(
+                                            "Hash size too small. Must be at least {} MB",
+                                            tt_table::MIN_TABLE_SIZE_MB
+                                        );
+                                        continue;
+                                    } else if hash_size > tt_table::MAX_TABLE_SIZE_MB {
+                                        eprintln!(
+                                            "Hash size too large. Must be at most {} MB",
+                                            tt_table::MAX_TABLE_SIZE_MB
+                                        );
+                                        continue;
+                                    }
+
+                                    self.transposition_table = Arc::new(Mutex::new(
+                                        TranspositionTable::from_size_in_mb(hash_size),
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                    UciCommand::Stop => {
                         self.search_thread.stop_search();
                     }
-
-                    let info = UciInfo::default().string(format!("searching {}", board.to_fen()));
-                    writeln!(stdout, "{}", UciResponse::info(info)).unwrap();
-
-                    // create the search parameters
-                    let search_params = SearchParameters::new(search_options, &board);
-                    // send them and the current board to the search thread
-                    self.search_thread
-                        .start_search(&board, search_params, tt.clone());
-                }
-                UciCommand::Stop => {
-                    self.search_thread.stop_search();
-                }
-                _ => {}
+                    _ => {}
+                },
+                CommandProxy::Engine(engine_command) => match engine_command {
+                    EngineCommand::HashInfo => {
+                        if let Ok(tt) = self.transposition_table.lock() {
+                            writeln!(
+                                stdout,
+                                "full: {:.2}% hits: {} access: {} collisions: {} cap: {}",
+                                tt.fullness(),
+                                tt.hits,
+                                tt.accesses,
+                                tt.collisions,
+                                tt.size(),
+                            )
+                            .unwrap();
+                        }
+                    }
+                },
             }
         }
 

--- a/engine/src/evaluation.rs
+++ b/engine/src/evaluation.rs
@@ -4,13 +4,15 @@
  * Created Date: Thursday, November 21st 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Thu Nov 21 2024
+ * Last Modified: Fri Nov 29 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
  * https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *
  */
+
+use std::i64;
 
 use chess::{board::Board, definitions::NumberOf, moves::Move, pieces::Piece};
 

--- a/engine/src/input_handler.rs
+++ b/engine/src/input_handler.rs
@@ -4,7 +4,7 @@
  * Created Date: Monday, November 18th 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Tue Nov 26 2024
+ * Last Modified: Fri Nov 29 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -22,14 +22,34 @@ use std::{
     },
     thread::JoinHandle,
 };
-
 use uci_parser::UciCommand;
+
+#[derive(Debug)]
+pub(crate) enum EngineCommand {
+    HashInfo,
+}
+
+impl FromStr for EngineCommand {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "hash" => Ok(EngineCommand::HashInfo),
+            _ => Err(anyhow::anyhow!("Invalid engine command")),
+        }
+    }
+}
+
+pub(crate) enum CommandProxy {
+    Uci(UciCommand),
+    Engine(EngineCommand),
+}
 
 #[derive(Debug)]
 pub(crate) struct InputHandler {
     handle: Option<JoinHandle<()>>,
     stop_flag: Arc<AtomicBool>,
-    receiver: Receiver<UciCommand>,
+    receiver: Receiver<CommandProxy>,
 }
 
 impl InputHandler {
@@ -54,16 +74,22 @@ impl InputHandler {
             let mut input = stdin.lock().lines();
             while !stop_flag.load(std::sync::atomic::Ordering::Relaxed) {
                 if let Some(Ok(line)) = input.next() {
-                    let command = UciCommand::from_str(line.as_str());
-                    if let Ok(command) = command {
-                        let cmd = command.clone();
-                        sender.send(command).unwrap();
-                        // manually break the loop if the command is "quit"
-                        if cmd == UciCommand::Quit {
-                            break;
-                        }
+                    let engine_command = EngineCommand::from_str(line.as_str());
+
+                    if let Ok(engine_command) = engine_command {
+                        sender.send(CommandProxy::Engine(engine_command)).unwrap();
                     } else {
-                        eprintln!("Invalid UCI command: {}", line);
+                        let command = UciCommand::from_str(line.as_str());
+                        if let Ok(command) = command {
+                            let cmd = command.clone();
+                            sender.send(CommandProxy::Uci(cmd)).unwrap();
+                            // manually break the loop if the command is "quit"
+                            if command == UciCommand::Quit {
+                                break;
+                            }
+                        } else {
+                            eprintln!("Invalid UCI command: {}", line);
+                        }
                     }
                 } else {
                     eprintln!("Error reading from stdin");
@@ -86,7 +112,7 @@ impl InputHandler {
         }
     }
 
-    pub fn receiver(&self) -> &Receiver<UciCommand> {
+    pub fn receiver(&self) -> &Receiver<CommandProxy> {
         &self.receiver
     }
 

--- a/engine/src/search_thread.rs
+++ b/engine/src/search_thread.rs
@@ -4,7 +4,7 @@
  * Created Date: Thursday, November 21st 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Thu Nov 28 2024
+ * Last Modified: Fri Nov 29 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -54,7 +54,11 @@ fn move_to_uci_move(mv: &Move) -> UciMove {
 
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum SearchThreadValue {
-    Params(Board, SearchParameters, Arc<Mutex<TranspositionTable>>),
+    Params(
+        Board,
+        SearchParameters,
+        Arc<Mutex<TranspositionTable<true>>>,
+    ),
     Exit,
 }
 
@@ -136,7 +140,7 @@ impl SearchThread {
         &self,
         board: &Board,
         params: SearchParameters,
-        tt: Arc<Mutex<TranspositionTable>>,
+        tt: Arc<Mutex<TranspositionTable<true>>>,
     ) {
         self.stop_search_flag.store(false, Ordering::Relaxed);
         self.sender

--- a/engine/src/tt_table.rs
+++ b/engine/src/tt_table.rs
@@ -4,7 +4,7 @@
  * Created Date: Thursday, November 21st 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Tue Nov 26 2024
+ * Last Modified: Thu Nov 28 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -54,8 +54,16 @@ impl TranspositionTableEntry {
 }
 
 /// A transposition table used to store the results of previous searches.
-pub(crate) struct TranspositionTable {
+pub struct TranspositionTable {
     table: Vec<Option<TranspositionTableEntry>>,
+}
+
+const DEFAULT_TABLE_SIZE_MB: usize = 16;
+
+impl Default for TranspositionTable {
+    fn default() -> Self {
+        Self::from_size_in_mb(DEFAULT_TABLE_SIZE_MB)
+    }
 }
 
 impl TranspositionTable {
@@ -82,5 +90,9 @@ impl TranspositionTable {
     pub(crate) fn store_entry(&mut self, entry: TranspositionTableEntry) {
         let index = self.get_index(entry.zobrist);
         self.table[index] = Some(entry);
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.table.clear();
     }
 }

--- a/engine/src/tt_table.rs
+++ b/engine/src/tt_table.rs
@@ -4,7 +4,7 @@
  * Created Date: Thursday, November 21st 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Thu Nov 28 2024
+ * Last Modified: Fri Nov 29 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -54,22 +54,30 @@ impl TranspositionTableEntry {
 }
 
 /// A transposition table used to store the results of previous searches.
-pub struct TranspositionTable {
+pub struct TranspositionTable<const TRACK_STATS: bool> {
     table: Vec<Option<TranspositionTableEntry>>,
+    pub(crate) collisions: usize,
+    pub(crate) accesses: usize,
+    pub(crate) hits: usize,
 }
 
-const DEFAULT_TABLE_SIZE_MB: usize = 16;
+pub const MAX_TABLE_SIZE_MB: usize = 1024;
+pub const MIN_TABLE_SIZE_MB: usize = 16;
+const DEFAULT_TABLE_SIZE_MB: usize = MIN_TABLE_SIZE_MB;
 
-impl Default for TranspositionTable {
+impl<const TRACK_STATS: bool> Default for TranspositionTable<TRACK_STATS> {
     fn default() -> Self {
         Self::from_size_in_mb(DEFAULT_TABLE_SIZE_MB)
     }
 }
 
-impl TranspositionTable {
+impl<const TRACK_STATS: bool> TranspositionTable<TRACK_STATS> {
     pub(crate) fn from_capacity(capacity: usize) -> Self {
         Self {
             table: vec![None; capacity],
+            collisions: 0,
+            accesses: 0,
+            hits: 0,
         }
     }
 
@@ -82,13 +90,32 @@ impl TranspositionTable {
         zobrist as usize % self.table.len()
     }
 
-    pub(crate) fn get_entry(&self, zobrist: u64) -> Option<TranspositionTableEntry> {
+    pub(crate) fn get_entry(&mut self, zobrist: u64) -> Option<TranspositionTableEntry> {
+        if TRACK_STATS {
+            self.accesses += 1;
+        }
+
         let index = self.get_index(zobrist);
-        self.table[index]
+        let entry = self.table[index];
+
+        if TRACK_STATS {
+            if entry.is_some() {
+                self.hits += 1;
+            }
+        }
+        entry
     }
 
     pub(crate) fn store_entry(&mut self, entry: TranspositionTableEntry) {
         let index = self.get_index(entry.zobrist);
+        if TRACK_STATS {
+            let old = self.table[index];
+            if let Some(old) = old {
+                if old.zobrist == entry.zobrist {
+                    self.collisions += 1;
+                }
+            }
+        }
         self.table[index] = Some(entry);
     }
 
@@ -96,5 +123,19 @@ impl TranspositionTable {
         self.table.iter_mut().for_each(|element| {
             *element = None;
         });
+
+        // reset stats as well
+        self.collisions = 0;
+        self.accesses = 0;
+        self.hits = 0;
+    }
+
+    pub(crate) fn fullness(&self) -> f64 {
+        (self.table.iter().filter(|entry| entry.is_some()).count() as f64 / self.table.len() as f64)
+            * 100_f64
+    }
+
+    pub(crate) fn size(&self) -> usize {
+        self.table.len()
     }
 }

--- a/engine/src/tt_table.rs
+++ b/engine/src/tt_table.rs
@@ -93,6 +93,8 @@ impl TranspositionTable {
     }
 
     pub(crate) fn clear(&mut self) {
-        self.table.clear();
+        self.table.iter_mut().for_each(|element| {
+            *element = None;
+        });
     }
 }

--- a/src/bin/byte-knight/bench.rs
+++ b/src/bin/byte-knight/bench.rs
@@ -4,7 +4,7 @@
  * Created Date: Thursday, November 21st 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Thu Nov 21 2024
+ * Last Modified: Thu Nov 28 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -161,7 +161,8 @@ pub(crate) fn bench(depth: u8, epd_file: &Option<String>) {
     };
 
     let mut nodes = 0u64;
-    let mut search = Search::new(&config);
+    let mut tt = Default::default();
+    let mut search = Search::new(&config, &mut tt);
 
     for bench in benchmark_strings {
         let fen: &str = bench.split(";").next().unwrap();


### PR DESCRIPTION
Persist the tt table per game, not per search. Also added way to clear the table so that it is cleared between games.

Note that the engine is kinda broken now, so we will likely reset things and revert to a more basic negamax without transposition table support.

bench: 2577543