### PR TITLE
feat: shrink the tt entry object size

### DIFF
--- a/engine/src/evaluation.rs
+++ b/engine/src/evaluation.rs
@@ -4,7 +4,7 @@
  * Created Date: Thursday, November 21st 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Sat Nov 30 2024
+ * Last Modified: Mon Dec 02 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -14,12 +14,16 @@
 
 use chess::{board::Board, definitions::NumberOf, moves::Move, pieces::Piece};
 
-use crate::{psqt::Psqt, score::Score, ttable::TranspositionTableEntry};
+use crate::{
+    psqt::Psqt,
+    score::{Score, ScoreType},
+    ttable::TranspositionTableEntry,
+};
 
 // similar setup to Rustic https://rustic-chess.org/search/ordering/mvv_lva.html
 // MVV-LVA (Most Valuable Victim - Least Valuable Attacker) is a heuristic used to order captures.
 // MVV_LVA[victim][attacker] = victim_value - attacker_value
-const MVV_LVA: [[i64; NumberOf::PIECE_TYPES + 1]; NumberOf::PIECE_TYPES + 1] = [
+const MVV_LVA: [[ScoreType; NumberOf::PIECE_TYPES + 1]; NumberOf::PIECE_TYPES + 1] = [
     [0, 0, 0, 0, 0, 0, 0],             // victim K, attacker K, Q, R, B, N, P, None
     [500, 510, 520, 530, 540, 550, 0], // victim Q, attacker K, Q, R, B, N, P, None
     [400, 410, 420, 430, 440, 450, 0], // victim R, attacker K, Q, R, B, N, P, None
@@ -71,7 +75,7 @@ impl Evaluation {
         tt_entry: &Option<TranspositionTableEntry>,
     ) -> Score {
         if tt_entry.is_some_and(|tt| *mv == tt.board_move) {
-            return Score::new(i64::MIN);
+            return Score::new(ScoreType::MIN);
         }
         let mut score = Score::new(0);
 

--- a/engine/src/psqt.rs
+++ b/engine/src/psqt.rs
@@ -4,7 +4,7 @@
  * Created Date: Thursday, November 21st 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Tue Nov 26 2024
+ * Last Modified: Mon Dec 02 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -14,20 +14,20 @@
 
 use chess::{bitboard_helpers, board::Board, side::Side};
 
-use crate::score::Score;
+use crate::score::{Score, ScoreType};
 
 /// Mid-game piece values
 /// Ordered to match the indexing of [`Piece`]
 /// King, Queen, Rook, Bishop, Knight, Pawn
-const MG_VALUE: [i64; 6] = [0, 1025, 477, 365, 337, 82];
+const MG_VALUE: [ScoreType; 6] = [0, 1025, 477, 365, 337, 82];
 
 /// End-game piece values
 /// Ordered to match the indexing of [`Piece`]
 /// King, Queen, Rook, Bishop, Knight, Pawn
-const EG_VALUE: [i64; 6] = [0, 936, 512, 297, 281, 94];
+const EG_VALUE: [ScoreType; 6] = [0, 936, 512, 297, 281, 94];
 
 #[rustfmt::skip]
-const MG_PAWN_TABLE: [i64; 64] = [
+const MG_PAWN_TABLE: [ScoreType; 64] = [
     0, 0, 0, 0, 0, 0, 0, 0,
     98, 134, 61, 95, 68, 126, 34, -11,
     -6, 7, 26, 31, 65, 56, 25, -20,
@@ -39,7 +39,7 @@ const MG_PAWN_TABLE: [i64; 64] = [
 ];
 
 #[rustfmt::skip]
-const EG_PAWN_TABLE: [i64; 64] = [
+const EG_PAWN_TABLE: [ScoreType; 64] = [
     0, 0, 0, 0, 0, 0, 0, 0,
     178, 173, 158, 134, 147, 132, 165, 187,
     94, 100, 85, 67, 56, 53, 82, 84,
@@ -51,7 +51,7 @@ const EG_PAWN_TABLE: [i64; 64] = [
 ];
 
 #[rustfmt::skip]
-const MG_KNIGHT_TABLE: [i64; 64] = [
+const MG_KNIGHT_TABLE: [ScoreType; 64] = [
     -167, -89, -34, -49, 61, -97, -15, -107,
     -73, -41, 72, 36, 23, 62, 7, -17,
     -47, 60, 37, 65, 84, 129, 73, 44,
@@ -63,7 +63,7 @@ const MG_KNIGHT_TABLE: [i64; 64] = [
 ];
 
 #[rustfmt::skip]
-const EG_KNIGHT_TABLE: [i64; 64] = [
+const EG_KNIGHT_TABLE: [ScoreType; 64] = [
     -58, -38, -13, -28, -31, -27, -63, -99,
     -25, -8, -25, -2, -9, -25, -24, -52,
     -24, -20, 10, 9, -1, -9, -19, -41,
@@ -75,7 +75,7 @@ const EG_KNIGHT_TABLE: [i64; 64] = [
 ];
 
 #[rustfmt::skip]
-const MG_BISHOP_TABLE: [i64; 64] = [
+const MG_BISHOP_TABLE: [ScoreType; 64] = [
     -29, 4, -82, -37, -25, -42, 7, -8,
     -26, 16, -18, -13, 30, 59, 18, -47,
     -16, 37, 43, 40, 35, 50, 37, -2,
@@ -87,7 +87,7 @@ const MG_BISHOP_TABLE: [i64; 64] = [
 ];
 
 #[rustfmt::skip]
-const EG_BISHOP_TABLE: [i64; 64] = [
+const EG_BISHOP_TABLE: [ScoreType; 64] = [
     -14, -21, -11, -8, -7, -9, -17, -24,
     -8, -4, 7, -12, -3, -13, -4, -14,
     2, -8, 0, -1, -2, 6, 0, 4,
@@ -99,7 +99,7 @@ const EG_BISHOP_TABLE: [i64; 64] = [
 ];
 
 #[rustfmt::skip]
-const MG_ROOK_TABLE: [i64; 64] = [
+const MG_ROOK_TABLE: [ScoreType; 64] = [
     32, 42, 32, 51, 63, 9, 31, 43,
     27, 32, 58, 62, 80, 67, 26, 44,
     -5, 19, 26, 36, 17, 45, 61, 16,
@@ -111,7 +111,7 @@ const MG_ROOK_TABLE: [i64; 64] = [
 ];
 
 #[rustfmt::skip]
-const EG_ROOK_TABLE: [i64; 64] = [
+const EG_ROOK_TABLE: [ScoreType; 64] = [
     13, 10, 18, 15, 12, 12, 8, 5,
     11, 13, 13, 11, -3, 3, 8, 3,
     7, 7, 7, 5, 4, -3, -5, -3,
@@ -123,7 +123,7 @@ const EG_ROOK_TABLE: [i64; 64] = [
 ];
 
 #[rustfmt::skip]
-const MG_QUEEN_TABLE: [i64; 64] = [
+const MG_QUEEN_TABLE: [ScoreType; 64] = [
     -28, 0, 29, 12, 59, 44, 43, 45,
     -24, -39, -5, 1, -16, 57, 28, 54,
     -13, -17, 7, 8, 29, 56, 47, 57,
@@ -135,7 +135,7 @@ const MG_QUEEN_TABLE: [i64; 64] = [
 ];
 
 #[rustfmt::skip]
-const EG_QUEEN_TABLE: [i64; 64] = [
+const EG_QUEEN_TABLE: [ScoreType; 64] = [
     -9, 22, 22, 27, 27, 19, 10, 20,
     -17, 20, 32, 41, 58, 25, 30, 0,
     -20, 6, 9, 49, 47, 35, 19, 9,
@@ -147,7 +147,7 @@ const EG_QUEEN_TABLE: [i64; 64] = [
 ];
 
 #[rustfmt::skip]
-const MG_KING_TABLE: [i64; 64] = [
+const MG_KING_TABLE: [ScoreType; 64] = [
     -65, 23, 16, -15, -56, -34, 2, 13,
     29, -1, -20, -7, -8, -4, -38, -29,
     -9, 24, 2, -16, -20, 6, 22, -22,
@@ -159,7 +159,7 @@ const MG_KING_TABLE: [i64; 64] = [
 ];
 
 #[rustfmt::skip]
-const EG_KING_TABLE: [i64; 64] = [
+const EG_KING_TABLE: [ScoreType; 64] = [
     -74, -35, -18, -18, -11, 15, 4, -17,
     -12, 17, 14, 17, 17, 38, 23, 11,
     10, 17, 23, 15, 20, 45, 44, 13,
@@ -172,7 +172,7 @@ const EG_KING_TABLE: [i64; 64] = [
 
 /// Opening/mid-game piece-square tables
 /// Ordered to match the indexing of [`Piece`]
-const MG_PESTO_TABLE: [&[i64; 64]; 6] = [
+const MG_PESTO_TABLE: [&[ScoreType; 64]; 6] = [
     &MG_KING_TABLE,
     &MG_QUEEN_TABLE,
     &MG_ROOK_TABLE,
@@ -183,7 +183,7 @@ const MG_PESTO_TABLE: [&[i64; 64]; 6] = [
 
 /// Endgame piece-square tables
 /// Ordered to match the indexing of [`Piece`]
-const EG_PESTO_TABLE: [&[i64; 64]; 6] = [
+const EG_PESTO_TABLE: [&[ScoreType; 64]; 6] = [
     &EG_KING_TABLE,
     &EG_QUEEN_TABLE,
     &EG_ROOK_TABLE,
@@ -195,12 +195,12 @@ const EG_PESTO_TABLE: [&[i64; 64]; 6] = [
 /// Game phase increment for each piece
 /// Ordered to match the indexing of [`Piece`]
 /// King, Queen, Rook, Bishop, Knight, Pawn
-const GAMEPHASE_INC: [i64; 6] = [0, 4, 2, 1, 1, 0];
+const GAMEPHASE_INC: [ScoreType; 6] = [0, 4, 2, 1, 1, 0];
 
 /// Piece-Square Tables (PST) for evaluation
 pub(crate) struct Psqt {
-    mg_table: [[i64; 64]; 12],
-    eg_table: [[i64; 64]; 12],
+    mg_table: [[ScoreType; 64]; 12],
+    eg_table: [[ScoreType; 64]; 12],
 }
 
 const FLIP: fn(usize) -> usize = |sq| sq ^ 56;

--- a/engine/src/score.rs
+++ b/engine/src/score.rs
@@ -4,7 +4,7 @@
  * Created Date: Thursday, November 14th 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Fri Nov 29 2024
+ * Last Modified: Mon Dec 02 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -19,24 +19,25 @@ use std::{
 
 use uci_parser::UciScore;
 
+pub(crate) type ScoreType = i16;
 /// Represents a score in centipawns.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Score(pub i64);
+pub struct Score(pub ScoreType);
 
 impl Score {
     pub const DRAW: Score = Score(0);
-    pub const MATE: Score = Score(i32::MAX as i64);
+    pub const MATE: Score = Score(i16::MAX as ScoreType);
     /// We use i32 so we don't overflow
-    pub const INF: Score = Score(i32::MAX as i64);
+    pub const INF: Score = Score(i16::MAX as ScoreType);
 
-    pub fn new(score: i64) -> Score {
+    pub fn new(score: ScoreType) -> Score {
         Score(score)
     }
 }
 
 impl From<Score> for UciScore {
     fn from(value: Score) -> Self {
-        UciScore::cp(value.0 as i32)
+        UciScore::cp(value.0.into())
     }
 }
 
@@ -64,8 +65,8 @@ impl AddAssign for Score {
     }
 }
 
-impl AddAssign<i64> for Score {
-    fn add_assign(&mut self, other: i64) {
+impl AddAssign<ScoreType> for Score {
+    fn add_assign(&mut self, other: ScoreType) {
         self.0 += other;
     }
 }
@@ -78,10 +79,10 @@ impl Add for Score {
     }
 }
 
-impl Add<i64> for Score {
+impl Add<ScoreType> for Score {
     type Output = Score;
 
-    fn add(self, other: i64) -> Score {
+    fn add(self, other: ScoreType) -> Score {
         Score(self.0 + other)
     }
 }

--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -4,7 +4,7 @@
  * Created Date: Thursday, November 21st 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Sun Dec 01 2024
+ * Last Modified: Mon Dec 02 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -27,7 +27,7 @@ use uci_parser::{UciInfo, UciResponse, UciSearchOptions};
 
 use crate::{
     evaluation::Evaluation,
-    score::Score,
+    score::{Score, ScoreType},
     ttable::{self, TranspositionTableEntry},
 };
 use ttable::TranspositionTable;
@@ -225,7 +225,7 @@ impl<'a> Search<'a> {
             && best_result.depth <= self.parameters.max_depth
         {
             // search the tree, starting at the current depth (starts at 1)
-            let score = self.negamax(board, best_result.depth as i64, 0, -Score::INF, Score::INF);
+            let score = self.negamax(board, best_result.depth as ScoreType, 0, -Score::INF, Score::INF);
 
             // check stop conditions
             if self.should_stop_searching() {
@@ -265,8 +265,8 @@ impl<'a> Search<'a> {
     fn negamax(
         &mut self,
         board: &mut Board,
-        depth: i64,
-        ply: i64,
+        depth: ScoreType,
+        ply: ScoreType,
         alpha: Score,
         beta: Score,
     ) -> Score {
@@ -290,7 +290,7 @@ impl<'a> Search<'a> {
                 // depth must be greater or equal to the current depth and the board
                 // must be the same position. Without this checks, we could be looking up the wrong entry
                 // due to collisions since we use a modulo as the hash function
-                if tt_entry.depth as i64 >= depth && tt_entry.zobrist == zobrist {
+                if tt_entry.depth as ScoreType >= depth && tt_entry.zobrist == zobrist {
                     match tt_entry.flag {
                         ttable::EntryFlag::Exact => {
                             return tt_entry.score;

--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -4,7 +4,7 @@
  * Created Date: Thursday, November 21st 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Sat Nov 30 2024
+ * Last Modified: Sun Dec 01 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -379,7 +379,7 @@ impl<'a> Search<'a> {
 
         self.transposition_table
             .store_entry(TranspositionTableEntry::new(
-                board,
+                board.zobrist_hash(),
                 depth as u8,
                 best_score,
                 flag,

--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -225,7 +225,13 @@ impl<'a> Search<'a> {
             && best_result.depth <= self.parameters.max_depth
         {
             // search the tree, starting at the current depth (starts at 1)
-            let score = self.negamax(board, best_result.depth as ScoreType, 0, -Score::INF, Score::INF);
+            let score = self.negamax(
+                board,
+                best_result.depth as ScoreType,
+                0,
+                -Score::INF,
+                Score::INF,
+            );
 
             // check stop conditions
             if self.should_stop_searching() {

--- a/engine/src/ttable.rs
+++ b/engine/src/ttable.rs
@@ -4,7 +4,7 @@
  * Created Date: Thursday, November 21st 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Sat Nov 30 2024
+ * Last Modified: Mon Dec 02 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -12,7 +12,7 @@
  *
  */
 
-use chess::{board::Board, moves::Move};
+use chess::moves::Move;
 
 use crate::score::Score;
 
@@ -125,7 +125,7 @@ impl TranspositionTable {
 #[cfg(test)]
 mod tests {
     use chess::{
-        moves::{self, Move, MoveDescriptor},
+        moves::{Move, MoveDescriptor},
         pieces::Piece,
         square::Square,
     };
@@ -170,9 +170,10 @@ mod tests {
             mv2,
         ));
 
-        let stored_entry1 = tt.get_entry(hash1);
-        assert!(stored_entry1.is_some());
-        assert_eq!(stored_entry1.unwrap().board_move, mv1);
+        // TODO(PT) - If we every implement buckets in our ttable, this should be used to check for store/retrieve working correctly at the same index
+        // let stored_entry1 = tt.get_entry(hash1);
+        // assert!(stored_entry1.is_some());
+        // assert_eq!(stored_entry1.unwrap().board_move, mv1);
         let stored_entry2 = tt.get_entry(hash2);
         assert!(stored_entry2.is_some());
         assert_eq!(stored_entry2.unwrap().board_move, mv2);

--- a/engine/src/ttable.rs
+++ b/engine/src/ttable.rs
@@ -121,3 +121,60 @@ impl TranspositionTable {
         self.table.len()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use chess::{
+        moves::{self, Move, MoveDescriptor},
+        pieces::Piece,
+        square::Square,
+    };
+
+    use crate::score::Score;
+
+    use super::{EntryFlag, TranspositionTable, TranspositionTableEntry};
+
+    #[test]
+    fn store_and_retrieve() {
+        let mut tt = TranspositionTable::from_capacity(1000);
+        let hash1 = 123452341999_u64;
+        let hash2 = 2423498723999_u64;
+        let mv1 = Move::new(
+            &Square::from_square_index(3),
+            &Square::from_square_index(4),
+            MoveDescriptor::Castle,
+            Piece::Knight,
+            None,
+            None,
+        );
+        let mv2 = Move::new(
+            &Square::from_square_index(7),
+            &Square::from_square_index(10),
+            MoveDescriptor::Castle,
+            Piece::Knight,
+            None,
+            None,
+        );
+        tt.store_entry(TranspositionTableEntry::new(
+            hash1,
+            3,
+            Score::new(-123),
+            EntryFlag::Exact,
+            mv1,
+        ));
+        tt.store_entry(TranspositionTableEntry::new(
+            hash2,
+            3,
+            Score::new(123),
+            EntryFlag::Exact,
+            mv2,
+        ));
+
+        let stored_entry1 = tt.get_entry(hash1);
+        assert!(stored_entry1.is_some());
+        assert_eq!(stored_entry1.unwrap().board_move, mv1);
+        let stored_entry2 = tt.get_entry(hash2);
+        assert!(stored_entry2.is_some());
+        assert_eq!(stored_entry2.unwrap().board_move, mv2);
+    }
+}

--- a/engine/src/ttable.rs
+++ b/engine/src/ttable.rs
@@ -29,23 +29,23 @@ pub enum EntryFlag {
 #[derive(Clone, Copy)]
 pub(crate) struct TranspositionTableEntry {
     pub zobrist: u64,
-    pub depth: u8,
     pub score: Score,
-    pub flag: EntryFlag,
     pub board_move: Move,
+    pub depth: u8,
+    pub flag: EntryFlag,
 }
 
 impl TranspositionTableEntry {
     #[allow(dead_code)]
     pub fn new(
-        board: &Board,
+        zobrist: u64,
         depth: u8,
         score: Score,
         flag: EntryFlag,
         mv: Move,
     ) -> TranspositionTableEntry {
         TranspositionTableEntry {
-            zobrist: board.zobrist_hash(),
+            zobrist,
             depth,
             score,
             flag,


### PR DESCRIPTION
## Changes

- Switch from using `i64` to `i16` for `Score`.
- Due to above, shrink `TranspositionTableEntry` to 16 bits
- Fixed overflow issues when calculating score due to `Score` change
- Added a very basic `TranspositionTable` unit test. Will be expounded on if we ever implement tt buckets. 
- Altered `TranspositionTableEntry::new` to take the zobrist hash in directly.

```
Elo   | 5.28 +- 4.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=1MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 10.00]
Games | N: 7372 W: 1557 L: 1445 D: 4370
Penta | [84, 648, 2128, 724, 102]
https://developerpaul123.pythonanywhere.com/test/54/
```