### PR TITLE
fix: compare best to correct alpha

### DIFF
--- a/engine/src/score.rs
+++ b/engine/src/score.rs
@@ -28,7 +28,7 @@ impl Score {
     pub const DRAW: Score = Score(0);
     pub const MATE: Score = Score(ScoreType::MAX as ScoreType);
     pub const INF: Score = Score(ScoreType::MAX as ScoreType);
-    
+
     pub fn new(score: ScoreType) -> Score {
         Score(score)
     }

--- a/engine/src/score.rs
+++ b/engine/src/score.rs
@@ -26,10 +26,9 @@ pub struct Score(pub ScoreType);
 
 impl Score {
     pub const DRAW: Score = Score(0);
-    pub const MATE: Score = Score(i16::MAX as ScoreType);
-    /// We use i32 so we don't overflow
-    pub const INF: Score = Score(i16::MAX as ScoreType);
-
+    pub const MATE: Score = Score(ScoreType::MAX as ScoreType);
+    pub const INF: Score = Score(ScoreType::MAX as ScoreType);
+    
     pub fn new(score: ScoreType) -> Score {
         Score(score)
     }

--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -374,7 +374,7 @@ impl<'a> Search<'a> {
                 best_move = Some(*mv);
 
                 // update alpha
-                alpha_use = alpha.max(best_score);
+                alpha_use = alpha_use.max(best_score);
                 if alpha_use >= beta_use {
                     break;
                 }


### PR DESCRIPTION
STC regression results:
```
Elo   | 1.10 +- 3.08 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.12 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 17304 W: 5606 L: 5551 D: 6147
Penta | [392, 1438, 4962, 1443, 417]
https://developerpaul123.pythonanywhere.com/test/64/
```

bench: 1939944