### PR TITLE
chore: simplify mvv-lva calculation

### DIFF
--- a/engine/src/evaluation.rs
+++ b/engine/src/evaluation.rs
@@ -4,7 +4,7 @@
  * Created Date: Thursday, November 21st 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Mon Dec 02 2024
+ * Last Modified: Mon Dec 09 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -79,10 +79,29 @@ impl Evaluation {
         }
         let mut score = Score::new(0);
 
-        score += MVV_LVA[mv.captured_piece().unwrap_or(Piece::None) as usize][mv.piece() as usize];
+        // MVV-LVA for captures
+        if mv.is_en_passant_capture() || mv.captured_piece().is_some() {
+            // safe to unwrap because we know it's a capture
+            // TODO: Tune/adjust the victim multiplier. Roughly we scale so that PxQ is worth the most
+            // We roughly scale the value of the victim by 40 so that the max value is 40 *800 = 32000, which is still less than a TT match
+            score += 40 * Evaluation::piece_value(mv.captured_piece().unwrap())
+                - Evaluation::piece_value(mv.piece());
+        }
 
         // negate the score to get the best move first
         -score
+    }
+
+    pub(crate) fn piece_value(piece: Piece) -> ScoreType {
+        match piece {
+            Piece::King => 0,
+            Piece::Queen => 900,
+            Piece::Rook => 500,
+            Piece::Bishop => 330,
+            Piece::Knight => 320,
+            Piece::Pawn => 100,
+            Piece::None => 0,
+        }
     }
 }
 

--- a/engine/src/evaluation.rs
+++ b/engine/src/evaluation.rs
@@ -12,26 +12,13 @@
  *
  */
 
-use chess::{board::Board, definitions::NumberOf, moves::Move, pieces::Piece};
+use chess::{board::Board, moves::Move, pieces::Piece};
 
 use crate::{
-    psqt::{Psqt, MG_VALUE},
+    psqt::Psqt,
     score::{Score, ScoreType},
     ttable::TranspositionTableEntry,
 };
-
-// similar setup to Rustic https://rustic-chess.org/search/ordering/mvv_lva.html
-// MVV-LVA (Most Valuable Victim - Least Valuable Attacker) is a heuristic used to order captures.
-// MVV_LVA[victim][attacker] = victim_value - attacker_value
-const MVV_LVA: [[ScoreType; NumberOf::PIECE_TYPES + 1]; NumberOf::PIECE_TYPES + 1] = [
-    [0, 0, 0, 0, 0, 0, 0],             // victim K, attacker K, Q, R, B, N, P, None
-    [500, 510, 520, 530, 540, 550, 0], // victim Q, attacker K, Q, R, B, N, P, None
-    [400, 410, 420, 430, 440, 450, 0], // victim R, attacker K, Q, R, B, N, P, None
-    [300, 310, 320, 330, 340, 350, 0], // victim B, attacker K, Q, R, B, N, P, None
-    [200, 210, 220, 230, 240, 250, 0], // victim N, attacker K, Q, R, B, N, P, None
-    [100, 110, 120, 130, 140, 150, 0], // victim P, attacker K, Q, R, B, N, P, None
-    [0, 0, 0, 0, 0, 0, 0],             // victim None, attacker K, Q, R, B, N, P, None
-];
 
 /// Provides static evaluation of a given chess position.
 pub struct Evaluation {

--- a/engine/src/evaluation.rs
+++ b/engine/src/evaluation.rs
@@ -83,9 +83,11 @@ impl Evaluation {
         if mv.is_en_passant_capture() || mv.captured_piece().is_some() {
             // safe to unwrap because we know it's a capture
             // TODO: Tune/adjust the victim multiplier. Roughly we scale so that PxQ is worth the most
-            // We roughly scale the value of the victim by 40 so that the max value is 40 *800 = 32000, which is still less than a TT match
-            score += 34 * Evaluation::piece_value(mv.captured_piece().unwrap())
-                - Evaluation::piece_value(mv.piece());
+            // max score is 30 - 1 = 29
+            // min score = PxQ = 6 - 5 = 1
+            score += 6 * Evaluation::piece_value(mv.captured_piece().unwrap())
+                - Evaluation::piece_value(mv.piece())
+                + 32_700;
         }
 
         // negate the score to get the best move first
@@ -93,7 +95,15 @@ impl Evaluation {
     }
 
     pub(crate) fn piece_value(piece: Piece) -> ScoreType {
-        MG_VALUE[piece as usize]
+        match piece {
+            Piece::King => 0,
+            Piece::Queen => 5,
+            Piece::Rook => 4,
+            Piece::Bishop => 3,
+            Piece::Knight => 2,
+            Piece::Pawn => 1,
+            Piece::None => 0,
+        }
     }
 }
 

--- a/engine/src/evaluation.rs
+++ b/engine/src/evaluation.rs
@@ -15,7 +15,7 @@
 use chess::{board::Board, definitions::NumberOf, moves::Move, pieces::Piece};
 
 use crate::{
-    psqt::Psqt,
+    psqt::{Psqt, MG_VALUE},
     score::{Score, ScoreType},
     ttable::TranspositionTableEntry,
 };
@@ -84,7 +84,7 @@ impl Evaluation {
             // safe to unwrap because we know it's a capture
             // TODO: Tune/adjust the victim multiplier. Roughly we scale so that PxQ is worth the most
             // We roughly scale the value of the victim by 40 so that the max value is 40 *800 = 32000, which is still less than a TT match
-            score += 40 * Evaluation::piece_value(mv.captured_piece().unwrap())
+            score += 34 * Evaluation::piece_value(mv.captured_piece().unwrap())
                 - Evaluation::piece_value(mv.piece());
         }
 
@@ -93,15 +93,7 @@ impl Evaluation {
     }
 
     pub(crate) fn piece_value(piece: Piece) -> ScoreType {
-        match piece {
-            Piece::King => 0,
-            Piece::Queen => 900,
-            Piece::Rook => 500,
-            Piece::Bishop => 330,
-            Piece::Knight => 320,
-            Piece::Pawn => 100,
-            Piece::None => 0,
-        }
+        MG_VALUE[piece as usize]
     }
 }
 

--- a/engine/src/evaluation.rs
+++ b/engine/src/evaluation.rs
@@ -120,7 +120,7 @@ mod tests {
         // note that these scores are for ordering, so they are negated
         assert_eq!(
             -Evaluation::score_move_for_ordering(&mv, &None),
-            Score::new(550)
+            Score::new(32729)
         );
 
         mv = Move::new(
@@ -134,7 +134,7 @@ mod tests {
 
         assert_eq!(
             -Evaluation::score_move_for_ordering(&mv, &None),
-            Score::new(430)
+            Score::new(32721)
         );
 
         mv = Move::new(
@@ -148,7 +148,7 @@ mod tests {
 
         assert_eq!(
             -Evaluation::score_move_for_ordering(&mv, &None),
-            Score::new(140)
+            Score::new(32704)
         );
     }
 }

--- a/engine/src/psqt.rs
+++ b/engine/src/psqt.rs
@@ -4,7 +4,7 @@
  * Created Date: Thursday, November 21st 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Mon Dec 02 2024
+ * Last Modified: Mon Dec 09 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -19,7 +19,7 @@ use crate::score::{Score, ScoreType};
 /// Mid-game piece values
 /// Ordered to match the indexing of [`Piece`]
 /// King, Queen, Rook, Bishop, Knight, Pawn
-const MG_VALUE: [ScoreType; 6] = [0, 1025, 477, 365, 337, 82];
+pub(crate) const MG_VALUE: [ScoreType; 6] = [0, 1025, 477, 365, 337, 82];
 
 /// End-game piece values
 /// Ordered to match the indexing of [`Piece`]


### PR DESCRIPTION
Prep work for history heuristic implementation (see #42)
```
Elo   | 0.30 +- 2.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 24166 W: 7777 L: 7756 D: 8633
Penta | [617, 2101, 6664, 2046, 655]
https://developerpaul123.pythonanywhere.com/test/69/
```

bench: 1938302