### PR TITLE
fix: mvv-lva scaling and minor issue with scoring for king captures

### DIFF
--- a/engine/src/evaluation.rs
+++ b/engine/src/evaluation.rs
@@ -77,7 +77,10 @@ impl Evaluation {
     }
 
     fn mvv_lva(captured: Piece, capturing: Piece) -> MoveOrderScoreType {
-        (25 * Evaluation::piece_value(captured) - Evaluation::piece_value(capturing)) << 16
+        let can_capture = captured != Piece::King && captured != Piece::None;
+        ((can_capture as MoveOrderScoreType)
+            * (25 * Evaluation::piece_value(captured) - Evaluation::piece_value(capturing)))
+            << 16
     }
 
     pub(crate) fn piece_value(piece: Piece) -> MoveOrderScoreType {
@@ -97,7 +100,7 @@ impl Evaluation {
 mod tests {
     use chess::{
         moves::{self, Move},
-        pieces::{Piece, PIECE_SHORT_NAMES},
+        pieces::{Piece, ALL_PIECES, PIECE_SHORT_NAMES},
         square::Square,
     };
 
@@ -105,25 +108,13 @@ mod tests {
 
     #[test]
     fn mvv_lva_scaling() {
-        for captured in &[
-            Piece::Pawn,
-            Piece::Knight,
-            Piece::Bishop,
-            Piece::Rook,
-            Piece::Queen,
-        ] {
-            for capturing in &[
-                Piece::Pawn,
-                Piece::Knight,
-                Piece::Bishop,
-                Piece::Rook,
-                Piece::Queen,
-            ] {
-                let score = Evaluation::mvv_lva(*captured, *capturing);
+        for captured in ALL_PIECES {
+            for capturing in ALL_PIECES {
+                let score = Evaluation::mvv_lva(captured, capturing);
                 println!(
                     "{} x {} -> {}",
-                    PIECE_SHORT_NAMES[*capturing as usize],
-                    PIECE_SHORT_NAMES[*captured as usize],
+                    PIECE_SHORT_NAMES[capturing as usize],
+                    PIECE_SHORT_NAMES[captured as usize],
                     score
                 );
                 assert!((score as i64) < (MoveOrderScoreType::MIN as i64).abs());

--- a/engine/src/score.rs
+++ b/engine/src/score.rs
@@ -20,6 +20,7 @@ use std::{
 use uci_parser::UciScore;
 
 pub(crate) type ScoreType = i16;
+pub(crate) type MoveOrderScoreType = i32;
 /// Represents a score in centipawns.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub struct Score(pub ScoreType);

--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -4,7 +4,7 @@
  * Created Date: Thursday, November 21st 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Mon Dec 02 2024
+ * Last Modified: Tue Dec 10 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later


### PR DESCRIPTION
## Changes

- King captures should not happen and they are generally an invalid state to handle in MVV/LVA move ordering, so we return 0 in that case. 
- Switched to using `i32` for move order scoring.
- MVV/LVA values are bit shifted << 16. This will (hopefully) help with history heuristic implementation when we try again (see #42) 

bench: 1938302