### PR TITLE
feat: add history heuristic

### DIFF
--- a/chess/src/moves.rs
+++ b/chess/src/moves.rs
@@ -273,10 +273,20 @@ impl Move {
         }
     }
 
+    pub fn is_quiet(&self) -> bool {
+        let mv_desc = self.move_descriptor();
+        mv_desc != MoveDescriptor::EnPassantCapture
+            && self.captured_piece_value() == Piece::None as u32
+    }
+
+    fn captured_piece_value(&self) -> u32 {
+        (self.move_info >> MOVE_INFO_CAPTURED_PIECE_SHIFT) & 0b111
+    }
+
     /// Returns the captured [`Piece`] if any. Can be `None`.
     pub fn captured_piece(&self) -> Option<Piece> {
         // shift right and then mask 3 bits
-        let piece_value = (self.move_info >> MOVE_INFO_CAPTURED_PIECE_SHIFT) & 0b111_u32;
+        let piece_value = self.captured_piece_value();
         if piece_value == Piece::None as u32 {
             return None;
         }
@@ -332,6 +342,7 @@ mod tests {
             assert_eq!(m.to(), 10);
             assert!(!m.is_promotion());
             assert_eq!(m.captured_piece(), None);
+            assert!(m.is_quiet());
             assert_eq!(m.piece(), Piece::Pawn);
         }
         {
@@ -349,6 +360,7 @@ mod tests {
             assert_eq!(m.to(), 56);
             assert!(!m.is_promotion());
             assert_eq!(m.captured_piece().unwrap(), Piece::Rook);
+            assert!(!m.is_quiet());
             assert_eq!(m.piece(), Piece::Queen);
         }
         {

--- a/chess/src/moves.rs
+++ b/chess/src/moves.rs
@@ -4,7 +4,7 @@
  * Created Date: Monday, August 19th 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Wed Nov 20 2024
+ * Last Modified: Tue Dec 10 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -277,6 +277,7 @@ impl Move {
         let mv_desc = self.move_descriptor();
         mv_desc != MoveDescriptor::EnPassantCapture
             && self.captured_piece_value() == Piece::None as u32
+            && !self.is_promotion()
     }
 
     fn captured_piece_value(&self) -> u32 {
@@ -480,5 +481,49 @@ mod tests {
             assert_eq!(m.captured_piece(), None);
             assert_eq!(m.piece(), Piece::Pawn);
         }
+    }
+
+    #[test]
+    fn move_types() {
+        let from = Square::new(File::A, Rank::R2);
+        let to = Square::new(File::A, Rank::R4);
+
+        let mut mv = Move::new(
+            &from,
+            &to,
+            MoveDescriptor::None,
+            Piece::Pawn,
+            Some(Piece::Pawn),
+            None,
+        );
+
+        assert!(!mv.is_quiet());
+        assert!(!mv.is_en_passant_capture());
+        assert!(!mv.is_pawn_two_up());
+        assert!(!mv.is_castle());
+        assert!(!mv.is_promotion());
+        assert!(!mv.is_null_move());
+        assert!(mv.move_descriptor() == MoveDescriptor::None);
+        assert_eq!(mv.from(), from.to_square_index());
+        assert_eq!(mv.to(), to.to_square_index());
+
+        mv = Move::new(
+            &from,
+            &to,
+            MoveDescriptor::PawnTwoUp,
+            Piece::Pawn,
+            None,
+            None,
+        );
+
+        assert!(mv.is_quiet());
+        assert!(!mv.is_en_passant_capture());
+        assert!(mv.is_pawn_two_up());
+        assert!(!mv.is_castle());
+        assert!(!mv.is_promotion());
+        assert!(!mv.is_null_move());
+        assert!(mv.move_descriptor() == MoveDescriptor::PawnTwoUp);
+        assert_eq!(mv.from(), from.to_square_index());
+        assert_eq!(mv.to(), to.to_square_index());
     }
 }

--- a/chess/src/moves.rs
+++ b/chess/src/moves.rs
@@ -280,6 +280,10 @@ impl Move {
             && !self.is_promotion()
     }
 
+    pub fn is_capture(&self) -> bool {
+        self.captured_piece_value() != Piece::None as u32 || self.is_en_passant_capture()
+    }
+
     fn captured_piece_value(&self) -> u32 {
         (self.move_info >> MOVE_INFO_CAPTURED_PIECE_SHIFT) & 0b111
     }

--- a/chess/src/side.rs
+++ b/chess/src/side.rs
@@ -4,13 +4,15 @@
  * Created Date: Monday, November 25th 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Tue Nov 26 2024
+ * Last Modified: Tue Dec 10 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
  * https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *
  */
+
+use std::fmt::Display;
 
 /// Represents a side to play in chess.
 #[repr(usize)]
@@ -59,6 +61,16 @@ impl Side {
 impl Default for Side {
     fn default() -> Self {
         Self::White
+    }
+}
+
+impl Display for Side {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::White => write!(f, "W"),
+            Self::Black => write!(f, "B"),
+            Self::Both => write!(f, "W|B"),
+        }
     }
 }
 

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -4,7 +4,7 @@
  * Created Date: Friday, November 15th 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Sat Nov 30 2024
+ * Last Modified: Tue Dec 10 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -186,6 +186,11 @@ impl ByteKnight {
                                 tt.size(),
                             )
                             .unwrap();
+                        }
+                    }
+                    EngineCommand::History => {
+                        if let Ok(ht) = self.history_table.lock() {
+                            ht.print_for_side(board.side_to_move());
                         }
                     }
                 },

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -22,6 +22,7 @@ use uci_parser::{UciCommand, UciInfo, UciOption, UciResponse};
 
 use crate::{
     defs::About,
+    history_table::HistoryTable,
     input_handler::{CommandProxy, EngineCommand, InputHandler},
     search::SearchParameters,
     search_thread::SearchThread,
@@ -32,6 +33,7 @@ pub struct ByteKnight {
     input_handler: InputHandler,
     search_thread: SearchThread,
     transposition_table: Arc<Mutex<TranspositionTable>>,
+    history_table: Arc<Mutex<HistoryTable>>,
     debug: bool,
 }
 
@@ -41,6 +43,7 @@ impl ByteKnight {
             input_handler: InputHandler::new(),
             search_thread: SearchThread::new(),
             transposition_table: Default::default(),
+            history_table: Default::default(),
             debug: false,
         }
     }
@@ -48,6 +51,10 @@ impl ByteKnight {
     fn clear_hash_tables(&mut self) {
         if let Ok(tt) = self.transposition_table.lock().as_mut() {
             tt.clear();
+        }
+
+        if let Ok(ht) = self.history_table.lock().as_mut() {
+            ht.clear();
         }
     }
 
@@ -132,6 +139,7 @@ impl ByteKnight {
                             &board,
                             search_params,
                             self.transposition_table.clone(),
+                            self.history_table.clone(),
                         );
                     }
                     UciCommand::SetOption { name, value } => {

--- a/engine/src/evaluation.rs
+++ b/engine/src/evaluation.rs
@@ -104,6 +104,7 @@ mod tests {
     use chess::{
         moves::{self, Move},
         pieces::{Piece, ALL_PIECES, PIECE_SHORT_NAMES},
+        side::Side,
         square::Square,
     };
 

--- a/engine/src/evaluation.rs
+++ b/engine/src/evaluation.rs
@@ -12,9 +12,10 @@
  *
  */
 
-use chess::{board::Board, moves::Move, pieces::Piece};
+use chess::{board::Board, definitions::NumberOf, moves::Move, pieces::Piece, side::Side};
 
 use crate::{
+    history_table,
     psqt::Psqt,
     score::{MoveOrderScoreType, Score},
     ttable::TranspositionTableEntry,
@@ -58,8 +59,10 @@ impl Evaluation {
     ///
     /// The score of the move.
     pub(crate) fn score_move_for_ordering(
+        stm: Side,
         mv: &Move,
         tt_entry: &Option<TranspositionTableEntry>,
+        history_table: &history_table::HistoryTable,
     ) -> MoveOrderScoreType {
         if tt_entry.is_some_and(|tt| *mv == tt.board_move) {
             return MoveOrderScoreType::MIN;
@@ -134,7 +137,8 @@ mod tests {
             Some(Piece::Queen),
             None,
         );
-
+        let side = Side::Black;
+        let history_table = Default::default();
         // note that these scores are for ordering, so they are negated
         assert_eq!(
             -Evaluation::score_move_for_ordering(&mv, &None),

--- a/engine/src/evaluation.rs
+++ b/engine/src/evaluation.rs
@@ -12,7 +12,7 @@
  *
  */
 
-use chess::{board::Board, definitions::NumberOf, moves::Move, pieces::Piece, side::Side};
+use chess::{board::Board, moves::Move, pieces::Piece, side::Side};
 
 use crate::{
     history_table,
@@ -70,8 +70,12 @@ impl Evaluation {
         let mut score = 0;
 
         // MVV-LVA for captures
-        if mv.is_en_passant_capture() || mv.captured_piece().is_some() {
-            // safe to unwrap because we know it's a capture
+        if mv.is_quiet() {
+            //history heuristic
+            score += history_table.get(stm, mv.piece(), mv.from());
+        } else if mv.is_en_passant_capture() || mv.captured_piece().is_some() {
+            // mvv-lva for captures
+            // safe to unwrap the captured piece because we already checked
             score += Self::mvv_lva(mv.captured_piece().unwrap(), mv.piece());
         }
 

--- a/engine/src/evaluation.rs
+++ b/engine/src/evaluation.rs
@@ -67,13 +67,12 @@ impl Evaluation {
         if tt_entry.is_some_and(|tt| *mv == tt.board_move) {
             return MoveOrderScoreType::MIN;
         }
-        let mut score = 0;
 
-        // MVV-LVA for captures
+        let mut score = 0;
         if mv.is_quiet() {
             //history heuristic
-            score += history_table.get(stm, mv.piece(), mv.from());
-        } else if mv.is_en_passant_capture() || mv.captured_piece().is_some() {
+            score += history_table.get(stm, mv.piece(), mv.to());
+        } else if mv.is_capture() {
             // mvv-lva for captures
             // safe to unwrap the captured piece because we already checked
             score += Self::mvv_lva(mv.captured_piece().unwrap(), mv.piece());

--- a/engine/src/evaluation.rs
+++ b/engine/src/evaluation.rs
@@ -83,7 +83,7 @@ impl Evaluation {
         -score
     }
 
-    fn mvv_lva(captured: Piece, capturing: Piece) -> MoveOrderScoreType {
+    pub(crate) fn mvv_lva(captured: Piece, capturing: Piece) -> MoveOrderScoreType {
         let can_capture = captured != Piece::King && captured != Piece::None;
         ((can_capture as MoveOrderScoreType)
             * (25 * Evaluation::piece_value(captured) - Evaluation::piece_value(capturing)))
@@ -146,7 +146,7 @@ mod tests {
         let history_table = Default::default();
         // note that these scores are for ordering, so they are negated
         assert_eq!(
-            -Evaluation::score_move_for_ordering(&mv, &None),
+            -Evaluation::score_move_for_ordering(side, &mv, &None, &history_table),
             Evaluation::mvv_lva(mv.captured_piece().unwrap(), mv.piece())
         );
 
@@ -160,7 +160,7 @@ mod tests {
         );
 
         assert_eq!(
-            -Evaluation::score_move_for_ordering(&mv, &None),
+            -Evaluation::score_move_for_ordering(side, &mv, &None, &history_table),
             Evaluation::mvv_lva(mv.captured_piece().unwrap(), mv.piece())
         );
 
@@ -174,7 +174,7 @@ mod tests {
         );
 
         assert_eq!(
-            -Evaluation::score_move_for_ordering(&mv, &None),
+            -Evaluation::score_move_for_ordering(side, &mv, &None, &history_table),
             Evaluation::mvv_lva(mv.captured_piece().unwrap(), mv.piece())
         );
     }

--- a/engine/src/history_table.rs
+++ b/engine/src/history_table.rs
@@ -35,6 +35,21 @@ impl HistoryTable {
             }
         }
     }
+
+    pub(crate) fn print_for_side(&self, side: Side) {
+        for piece_type in 0..NumberOf::PIECE_TYPES {
+            println!("{} - {}", PIECE_NAMES[piece_type], side);
+            // print from white's perspective
+            for rank in (0..=NumberOf::RANKS - 1).rev() {
+                print!("|");
+                for file in 0..NumberOf::FILES {
+                    let square = file + rank * NumberOf::FILES;
+                    print!("{:3} ", self.table[side as usize][piece_type][square].0);
+                }
+                println!("|");
+            }
+        }
+    }
 }
 
 impl Default for HistoryTable {

--- a/engine/src/history_table.rs
+++ b/engine/src/history_table.rs
@@ -1,0 +1,82 @@
+use chess::{definitions::NumberOf, pieces::Piece, side::Side};
+
+use crate::score::Score;
+
+pub struct HistoryTable {
+    table: [[[Score; NumberOf::SQUARES]; NumberOf::PIECE_TYPES]; NumberOf::SIDES],
+}
+
+impl HistoryTable {
+    pub(crate) fn new() -> Self {
+        let table =
+            [[[Default::default(); NumberOf::SQUARES]; NumberOf::PIECE_TYPES]; NumberOf::SIDES];
+        Self { table }
+    }
+
+    pub(crate) fn get(&self, side: Side, piece: Piece, square: u8) -> Score {
+        assert!(side != Side::Both, "Side cannot be Both");
+        self.table[side as usize][piece as usize][square as usize]
+    }
+
+    pub(crate) fn update(&mut self, side: Side, piece: Piece, square: u8, bonus: Score) {
+        assert!(side != Side::Both, "Side cannot be Both");
+        let score = self.table[side as usize][piece as usize][square as usize];
+        let mut new_score = score.0 as i32 + bonus.0 as i32;
+        new_score = new_score.clamp(-Score::MAX_HISTORY.0 as i32, Score::MAX_HISTORY.0 as i32);
+        self.table[side as usize][piece as usize][square as usize] = Score::new(new_score as i16);
+    }
+
+    pub(crate) fn clear(&mut self) {
+        for side in 0..NumberOf::SIDES {
+            for piece_type in 0..NumberOf::PIECE_TYPES {
+                for square in 0..NumberOf::SQUARES {
+                    self.table[side][piece_type][square] = Default::default();
+                }
+            }
+        }
+    }
+}
+
+impl Default for HistoryTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chess::{definitions::Squares, pieces::Piece, side::Side};
+
+    use crate::score::Score;
+
+    use super::HistoryTable;
+
+    #[test]
+    fn initialize_history_table() {
+        let history_table = HistoryTable::new();
+        // loop through all sides, piece types, and squares
+        for side in 0..2 {
+            for piece_type in 0..6 {
+                for square in 0..64 {
+                    assert_eq!(
+                        history_table.table[side][piece_type][square],
+                        Default::default()
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn store_and_read() {
+        let mut history_table = HistoryTable::new();
+        let side = Side::Black;
+        let piece = Piece::Pawn;
+        let square = Squares::A1;
+        let score = Score::new(37);
+        history_table.update(side, piece, square, score);
+        assert_eq!(history_table.get(side, piece, square), score);
+        history_table.update(side, piece, square, score);
+        assert_eq!(history_table.get(side, piece, square), score + score);
+    }
+}

--- a/engine/src/input_handler.rs
+++ b/engine/src/input_handler.rs
@@ -4,7 +4,7 @@
  * Created Date: Monday, November 18th 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Fri Nov 29 2024
+ * Last Modified: Tue Dec 10 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -27,6 +27,7 @@ use uci_parser::UciCommand;
 #[derive(Debug)]
 pub(crate) enum EngineCommand {
     HashInfo,
+    History,
 }
 
 impl FromStr for EngineCommand {
@@ -35,6 +36,7 @@ impl FromStr for EngineCommand {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "hash" => Ok(EngineCommand::HashInfo),
+            "history" => Ok(EngineCommand::History),
             _ => Err(anyhow::anyhow!("Invalid engine command")),
         }
     }

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod defs;
 pub mod engine;
 pub mod evaluation;
+pub mod history_table;
 pub mod input_handler;
 pub mod psqt;
 pub mod score;

--- a/engine/src/score.rs
+++ b/engine/src/score.rs
@@ -30,8 +30,16 @@ impl Score {
     pub const MATE: Score = Score(ScoreType::MAX as ScoreType);
     pub const INF: Score = Score(ScoreType::MAX as ScoreType);
 
+    // Max/min score for history heuristic
+    // Must be lower then the minimum score for captures in MVV_LVA
+    pub const MAX_HISTORY: Score = Score(14999);
+
     pub fn new(score: ScoreType) -> Score {
         Score(score)
+    }
+
+    pub fn clamp(&self, min: ScoreType, max: ScoreType) -> Score {
+        Score(self.0.clamp(min, max))
     }
 }
 

--- a/engine/src/score.rs
+++ b/engine/src/score.rs
@@ -4,7 +4,7 @@
  * Created Date: Thursday, November 14th 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Mon Dec 02 2024
+ * Last Modified: Tue Dec 10 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -32,7 +32,7 @@ impl Score {
 
     // Max/min score for history heuristic
     // Must be lower then the minimum score for captures in MVV_LVA
-    pub const MAX_HISTORY: Score = Score(14999);
+    pub const MAX_HISTORY: MoveOrderScoreType = 16_384;
 
     pub fn new(score: ScoreType) -> Score {
         Score(score)

--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -343,7 +343,7 @@ impl<'a> Search<'a> {
             Evaluation::score_move_for_ordering(
                 board.side_to_move(),
                 mv,
-                &None,
+                &tt_entry,
                 &self.history_table,
             )
         });

--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -517,6 +517,8 @@ mod tests {
         ttable::TranspositionTable,
     };
 
+    use super::MoveOrderScoreType;
+
     #[test]
     fn white_mate_in_1() {
         let fen = "k7/8/KQ6/8/8/8/8/8 w - - 0 1";
@@ -654,8 +656,8 @@ mod tests {
             ..Default::default()
         };
 
-        let mut min_mvv_lva = ScoreType::MAX;
-        let mut max_mvv_lva = ScoreType::MIN;
+        let mut min_mvv_lva = MoveOrderScoreType::MAX;
+        let mut max_mvv_lva = MoveOrderScoreType::MIN;
         for capturing in ALL_PIECES {
             for captured in ALL_PIECES.iter().filter(|p| !p.is_king() && !p.is_none()) {
                 let mvv_lva = Evaluation::mvv_lva(*captured, capturing);
@@ -679,7 +681,7 @@ mod tests {
             assert!(res.best_move.is_some());
 
             let side = board.side_to_move();
-            let mut max_history = Score::new(ScoreType::MIN);
+            let mut max_history = MoveOrderScoreType::MIN;
             for piece in ALL_PIECES {
                 for square in 0..64 {
                     let score = history_table.get(side, piece, square);
@@ -689,9 +691,9 @@ mod tests {
                 }
             }
 
-            println!("max history: {:5}", max_history.0);
+            println!("max history: {:5}", max_history);
             println!("min/max mvv-lva: {}, {}", min_mvv_lva, max_mvv_lva);
-            assert!(max_history.0 < min_mvv_lva);
+            assert!(max_history < min_mvv_lva);
         }
     }
 }

--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -4,7 +4,7 @@
  * Created Date: Thursday, November 21st 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Tue Dec 10 2024
+ * Last Modified: Wed Dec 11 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -155,7 +155,7 @@ impl<'a> Search<'a> {
     ) -> Self {
         Search {
             transposition_table: ttable,
-            history_table: history_table,
+            history_table,
             move_gen: MoveGenerator::new(),
             nodes: 0,
             parameters: parameters.clone(),
@@ -344,7 +344,7 @@ impl<'a> Search<'a> {
                 board.side_to_move(),
                 mv,
                 &tt_entry,
-                &self.history_table,
+                self.history_table,
             )
         });
 
@@ -463,12 +463,7 @@ impl<'a> Search<'a> {
         }
 
         let sorted_moves = captures.into_iter().sorted_by_cached_key(|mv| {
-            Evaluation::score_move_for_ordering(
-                board.side_to_move(),
-                mv,
-                &None,
-                &self.history_table,
-            )
+            Evaluation::score_move_for_ordering(board.side_to_move(), mv, &None, self.history_table)
         });
         let mut best = standing_eval;
 
@@ -511,8 +506,7 @@ mod tests {
 
     use crate::{
         evaluation::Evaluation,
-        history_table::{self, HistoryTable},
-        score::{Score, ScoreType},
+        score::Score,
         search::{Search, SearchParameters},
         ttable::TranspositionTable,
     };

--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -21,19 +21,14 @@ use std::{
     time::{Duration, Instant},
 };
 
-use chess::{
-    board::Board,
-    move_generation::MoveGenerator,
-    move_list::MoveList,
-    moves::Move,
-};
+use chess::{board::Board, move_generation::MoveGenerator, move_list::MoveList, moves::Move};
 use itertools::Itertools;
 use uci_parser::{UciInfo, UciResponse, UciSearchOptions};
 
 use crate::{
     evaluation::Evaluation,
     history_table::HistoryTable,
-    score::{Score, ScoreType},
+    score::{MoveOrderScoreType, Score, ScoreType},
     ttable::{self, TranspositionTableEntry},
 };
 use ttable::TranspositionTable;
@@ -396,13 +391,9 @@ impl<'a> Search<'a> {
                     // update history table for quiets
                     if mv.is_quiet() {
                         // calculate history bonus
-                        let bonus = (depth as ScoreType).pow(2);
-                        self.history_table.update(
-                            board.side_to_move(),
-                            mv.piece(),
-                            mv.to(),
-                            Score::new(bonus),
-                        );
+                        let bonus = (depth * depth) as MoveOrderScoreType;
+                        self.history_table
+                            .update(board.side_to_move(), mv.piece(), mv.to(), bonus);
                     }
 
                     break;

--- a/src/bin/byte-knight/bench.rs
+++ b/src/bin/byte-knight/bench.rs
@@ -162,7 +162,8 @@ pub(crate) fn bench(depth: u8, epd_file: &Option<String>) {
 
     let mut nodes = 0u64;
     let mut tt = Default::default();
-    let mut search = Search::new(&config, &mut tt);
+    let mut hist = Default::default();
+    let mut search = Search::new(&config, &mut tt, &mut hist);
 
     for bench in benchmark_strings {
         let fen: &str = bench.split(";").next().unwrap();


### PR DESCRIPTION
## Changes

- First attempt at a basic history heuristic for move ordering. Uses `depth*depth` for score bonus updates.

See #42 

```
Elo   | 43.15 +- 19.14 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.05 (-2.94, 2.94) [0.00, 10.00]
Games | N: 696 W: 266 L: 180 D: 250
Penta | [16, 60, 135, 96, 41]
https://pyronomy.pythonanywhere.com/test/354/
```

bench: 1546626