### PR TITLE
feat: implement aspiration windows

### DIFF
--- a/engine/src/aspiration_window.rs
+++ b/engine/src/aspiration_window.rs
@@ -14,8 +14,8 @@ pub(crate) struct AspirationWindow {
 impl AspirationWindow {
     pub(crate) fn infinite() -> Self {
         Self {
-            alpha: -Score::INF,
-            beta: Score::INF,
+            alpha: Score::ALPHA,
+            beta: Score::BETA,
             value: Score::default(),
             alpha_fails: 0,
             beta_fails: 0,

--- a/engine/src/aspiration_window.rs
+++ b/engine/src/aspiration_window.rs
@@ -1,12 +1,11 @@
 use crate::{
     score::{Score, ScoreType},
-    tuneable::{INITIAL_ASPIRATION_WINDOW, MIN_ASPIRATION_DEPTH, MIN_ASPIRATION_WINDOW},
+    tuneable::{ASPIRATION_WINDOW, MIN_ASPIRATION_DEPTH, MIN_ASPIRATION_WINDOW},
 };
 
 pub(crate) struct AspirationWindow {
     alpha: Score,
     beta: Score,
-    value: Score,
     alpha_fails: u32,
     beta_fails: u32,
 }
@@ -16,7 +15,6 @@ impl AspirationWindow {
         Self {
             alpha: Score::ALPHA,
             beta: Score::BETA,
-            value: Score::default(),
             alpha_fails: 0,
             beta_fails: 0,
         }
@@ -38,16 +36,18 @@ impl AspirationWindow {
         score != Score::BETA && score >= self.beta
     }
 
+    /// Create a new [`AspirationWindow`] centered around the given score.
     pub(crate) fn around(score: Score, depth: ScoreType) -> Self {
-        if depth > MIN_ASPIRATION_DEPTH || score.is_mate() {
+        if depth <= MIN_ASPIRATION_DEPTH || score.is_mate() {
             // If the score is mate, we can't use the window as we would expect search results to fluctuate.
             // Set it to a full window and search again.
+            // We also want to do a full search on the first iteration (i.e. depth == 1);
             return Self::infinite();
         } else {
+            let window = Self::window_size(depth);
             Self {
-                alpha: (score - Self::window_size(depth)).max(Score::ALPHA),
-                beta: (score + Self::window_size(depth)).min(Score::BETA),
-                value: score,
+                alpha: (score - window).max(Score::ALPHA),
+                beta: (score + window).min(Score::BETA),
                 alpha_fails: 0,
                 beta_fails: 0,
             }
@@ -55,25 +55,23 @@ impl AspirationWindow {
     }
 
     pub(crate) fn widen_down(&mut self, score: Score, depth: ScoreType) {
-        self.value = score;
         let margin = Self::window_size(depth) << (self.alpha_fails + 1);
-        self.alpha = self.value - margin;
-        // reset beta to be (alpha + beta / 2)
-        self.beta = (self.alpha + self.beta) / 2;
+        self.alpha = (score - margin).max(Score::ALPHA);
         // save that this was a fail low
         self.alpha_fails += 1;
     }
 
     pub(crate) fn widen_up(&mut self, score: Score, depth: ScoreType) {
-        self.value = score;
-        let margin = Self::window_size(depth).0 << (self.beta_fails + 1);
-        self.beta = self.value + margin;
-        self.beta_fails += 1;
         // Note that we do not alter alpha here, as we are widening the window upwards.
+        let margin = Self::window_size(depth) << (self.beta_fails + 1);
+        let new_beta = (score.0 as i32 + margin.0 as i32).min(Score::BETA.0 as i32);
+        self.beta = Score::new(new_beta as ScoreType);
+        // save that this was a fail high
+        self.beta_fails += 1;
     }
 
     fn window_size(depth: ScoreType) -> Score {
-        let window = ((INITIAL_ASPIRATION_WINDOW << 2) / depth).max(MIN_ASPIRATION_WINDOW);
+        let window = (ASPIRATION_WINDOW + (50 / depth)).max(MIN_ASPIRATION_WINDOW);
         Score::new(window)
     }
 }

--- a/engine/src/aspiration_window.rs
+++ b/engine/src/aspiration_window.rs
@@ -1,0 +1,71 @@
+use crate::{
+    score::{Score, ScoreType},
+    tuneable::{INITIAL_ASPIRATION_WINDOW, MIN_ASPIRATION_WINDOW},
+};
+
+pub(crate) struct AspirationWindow {
+    alpha: Score,
+    beta: Score,
+    value: Score,
+    alpha_fails: u32,
+    beta_fails: u32,
+}
+
+impl AspirationWindow {
+    pub(crate) fn infinite() -> Self {
+        Self {
+            alpha: -Score::INF,
+            beta: Score::INF,
+            value: Score::default(),
+            alpha_fails: 0,
+            beta_fails: 0,
+        }
+    }
+
+    pub(crate) fn alpha(&self) -> Score {
+        self.alpha
+    }
+
+    pub(crate) fn beta(&self) -> Score {
+        self.beta
+    }
+
+    pub(crate) fn around(score: Score, depth: ScoreType) -> Self {
+        if score == Score::MATE {
+            // If the score is mate, we can't use the window as we would expect search results to fluctuate.
+            // Set it to a full window and search again.
+            return Self::infinite();
+        } else {
+            Self {
+                alpha: (score - Self::window_size(depth)).max(-Score::INF),
+                beta: (score + Self::window_size(depth)).min(Score::INF),
+                value: score,
+                alpha_fails: 0,
+                beta_fails: 0,
+            }
+        }
+    }
+
+    pub(crate) fn widen_down(&mut self, score: Score, depth: ScoreType) {
+        self.value = score;
+        let margin = Self::window_size(depth) << (self.alpha_fails + 1);
+        self.alpha = self.value - margin;
+        // reset beta to be (alpha + beta / 2)
+        self.beta = (self.alpha + self.beta) / 2;
+        // save that this was a fail low
+        self.alpha_fails += 1;
+    }
+
+    pub(crate) fn widen_up(&mut self, score: Score, depth: ScoreType) {
+        self.value = score;
+        let margin = Self::window_size(depth).0 << (self.beta_fails + 1);
+        self.beta = self.value + margin;
+        self.beta_fails += 1;
+        // Note that we do not alter alpha here, as we are widening the window upwards.
+    }
+
+    fn window_size(depth: ScoreType) -> Score {
+        let window = ((INITIAL_ASPIRATION_WINDOW << 3) / depth).max(MIN_ASPIRATION_WINDOW);
+        Score::new(window)
+    }
+}

--- a/engine/src/aspiration_window.rs
+++ b/engine/src/aspiration_window.rs
@@ -42,7 +42,7 @@ impl AspirationWindow {
             // If the score is mate, we can't use the window as we would expect search results to fluctuate.
             // Set it to a full window and search again.
             // We also want to do a full search on the first iteration (i.e. depth == 1);
-            return Self::infinite();
+            Self::infinite()
         } else {
             let window = Self::window_size(depth);
             Self {

--- a/engine/src/defs.rs
+++ b/engine/src/defs.rs
@@ -30,3 +30,5 @@ impl About {
     pub const AUTHORS: &'static str = "Paul T. (DeveloperPaul123)";
     pub const BANNER: &'static str = BANNER;
 }
+
+pub(crate) const MAX_DEPTH: u8 = 128;

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod aspiration_window;
 pub mod defs;
 pub mod engine;
 pub mod evaluation;
@@ -8,3 +9,4 @@ pub mod score;
 pub mod search;
 pub mod search_thread;
 pub mod ttable;
+pub mod tuneable;

--- a/engine/src/score.rs
+++ b/engine/src/score.rs
@@ -4,7 +4,7 @@
  * Created Date: Thursday, November 14th 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Tue Dec 10 2024
+ * Last Modified: Wed Dec 11 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -12,7 +12,7 @@
  *
  */
 
-use std::ops::{Sub, SubAssign};
+use std::ops::{Div, DivAssign, Mul, MulAssign, Shl, Sub, SubAssign};
 use std::{
     fmt::{self, Display, Formatter},
     ops::{Add, AddAssign, Neg},
@@ -118,5 +118,64 @@ impl SubAssign for Score {
 impl SubAssign<ScoreType> for Score {
     fn sub_assign(&mut self, rhs: ScoreType) {
         self.0 -= rhs;
+    }
+}
+
+impl Div<ScoreType> for Score {
+    type Output = Score;
+    fn div(self, rhs: ScoreType) -> Score {
+        Score(self.0 / rhs)
+    }
+}
+
+impl Div<Score> for Score {
+    type Output = Score;
+    fn div(self, rhs: Score) -> Score {
+        Score(self.0 / rhs.0)
+    }
+}
+
+impl DivAssign<ScoreType> for Score {
+    fn div_assign(&mut self, rhs: ScoreType) {
+        self.0 /= rhs;
+    }
+}
+
+impl DivAssign<Score> for Score {
+    fn div_assign(&mut self, rhs: Score) {
+        self.0 /= rhs.0;
+    }
+}
+
+impl Mul<ScoreType> for Score {
+    type Output = Score;
+    fn mul(self, rhs: ScoreType) -> Score {
+        Score(self.0 * rhs)
+    }
+}
+
+impl Mul<Score> for Score {
+    type Output = Score;
+    fn mul(self, rhs: Score) -> Score {
+        Score(self.0 * rhs.0)
+    }
+}
+
+impl MulAssign<ScoreType> for Score {
+    fn mul_assign(&mut self, rhs: ScoreType) {
+        self.0 *= rhs;
+    }
+}
+
+impl MulAssign<Score> for Score {
+    fn mul_assign(&mut self, rhs: Score) {
+        self.0 *= rhs.0;
+    }
+}
+
+impl Shl<u32> for Score {
+    type Output = Score;
+    fn shl(self, rhs: u32) -> Score {
+        Score(self.0 << rhs)
     }
 }

--- a/engine/src/score.rs
+++ b/engine/src/score.rs
@@ -4,7 +4,7 @@
  * Created Date: Thursday, November 14th 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Wed Dec 11 2024
+ * Last Modified: Thu Dec 12 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -42,6 +42,10 @@ impl Score {
 
     pub fn clamp(&self, min: ScoreType, max: ScoreType) -> Score {
         Score(self.0.clamp(min, max))
+    }
+
+    pub fn is_mate(&self) -> bool {
+        self.0.abs() >= Score::MATE.0.abs()
     }
 }
 

--- a/engine/src/score.rs
+++ b/engine/src/score.rs
@@ -29,6 +29,8 @@ impl Score {
     pub const DRAW: Score = Score(0);
     pub const MATE: Score = Score(ScoreType::MAX as ScoreType);
     pub const INF: Score = Score(ScoreType::MAX as ScoreType);
+    pub const ALPHA: Score = Score(-Score::INF.0);
+    pub const BETA: Score = Score::INF;
 
     // Max/min score for history heuristic
     // Must be lower then the minimum score for captures in MVV_LVA

--- a/engine/src/score.rs
+++ b/engine/src/score.rs
@@ -33,8 +33,6 @@ impl Score {
     /// The minimum mate score. This is the maximum score minus the maximum depth.
     pub const MINIMUM_MATE: Score = Score(Score::MATE.0 - MAX_DEPTH as ScoreType);
     pub const INF: Score = Score(ScoreType::MAX as ScoreType);
-    pub const ALPHA: Score = Score(-Score::INF.0);
-    pub const BETA: Score = Score::INF;
 
     // Max/min score for history heuristic
     // Must be lower then the minimum score for captures in MVV_LVA
@@ -52,6 +50,10 @@ impl Score {
     /// This is the case if the absolute value of the score is greater than or equal to `Score::MINIMUM_MATE`.
     pub fn is_mate(&self) -> bool {
         self.0.abs() >= Score::MINIMUM_MATE.0.abs()
+    }
+
+    pub fn pow(&self, exp: u32) -> Score {
+        Score(self.0.pow(exp))
     }
 }
 

--- a/engine/src/score.rs
+++ b/engine/src/score.rs
@@ -30,6 +30,7 @@ pub struct Score(pub ScoreType);
 impl Score {
     pub const DRAW: Score = Score(0);
     pub const MATE: Score = Score(ScoreType::MAX as ScoreType);
+    /// The minimum mate score. This is the maximum score minus the maximum depth.
     pub const MINIMUM_MATE: Score = Score(Score::MATE.0 - MAX_DEPTH as ScoreType);
     pub const INF: Score = Score(ScoreType::MAX as ScoreType);
     pub const ALPHA: Score = Score(-Score::INF.0);
@@ -47,6 +48,8 @@ impl Score {
         Score(self.0.clamp(min, max))
     }
 
+    /// Returns true if the score is a mate score.
+    /// This is the case if the absolute value of the score is greater than or equal to `Score::MINIMUM_MATE`.
     pub fn is_mate(&self) -> bool {
         self.0.abs() >= Score::MINIMUM_MATE.0.abs()
     }

--- a/engine/src/score.rs
+++ b/engine/src/score.rs
@@ -19,6 +19,8 @@ use std::{
 };
 use uci_parser::UciScore;
 
+use crate::defs::MAX_DEPTH;
+
 pub(crate) type ScoreType = i16;
 pub(crate) type MoveOrderScoreType = i32;
 /// Represents a score in centipawns.
@@ -28,6 +30,7 @@ pub struct Score(pub ScoreType);
 impl Score {
     pub const DRAW: Score = Score(0);
     pub const MATE: Score = Score(ScoreType::MAX as ScoreType);
+    pub const MINIMUM_MATE: Score = Score(Score::MATE.0 - MAX_DEPTH as ScoreType);
     pub const INF: Score = Score(ScoreType::MAX as ScoreType);
     pub const ALPHA: Score = Score(-Score::INF.0);
     pub const BETA: Score = Score::INF;
@@ -45,7 +48,7 @@ impl Score {
     }
 
     pub fn is_mate(&self) -> bool {
-        self.0.abs() >= Score::MATE.0.abs()
+        self.0.abs() >= Score::MINIMUM_MATE.0.abs()
     }
 }
 

--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -26,15 +26,9 @@ use itertools::Itertools;
 use uci_parser::{UciInfo, UciResponse, UciSearchOptions};
 
 use crate::{
-    aspiration_window::AspirationWindow,
-    evaluation::Evaluation,
-    history_table::HistoryTable,
-    score::{MoveOrderScoreType, Score, ScoreType},
-    ttable::{self, TranspositionTableEntry},
+    aspiration_window::AspirationWindow, defs::MAX_DEPTH, evaluation::Evaluation, history_table::HistoryTable, score::{MoveOrderScoreType, Score, ScoreType}, ttable::{self, TranspositionTableEntry}
 };
 use ttable::TranspositionTable;
-
-const MAX_DEPTH: u8 = 128;
 
 /// Result for a search.
 #[derive(Clone, Copy, Debug)]
@@ -225,6 +219,7 @@ impl<'a> Search<'a> {
         // initialize the best result
         let mut best_result = SearchResult::default();
         let mut move_list = MoveList::new();
+
         self.move_gen.generate_legal_moves(board, &mut move_list);
         if !move_list.is_empty() {
             best_result.best_move = Some(*move_list.at(0).unwrap())

--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -225,7 +225,7 @@ impl<'a> Search<'a> {
             best_result.best_move = Some(*move_list.at(0).unwrap())
         }
 
-        while self.parameters.start_time.elapsed() <= self.parameters.soft_timeout
+        'deepening: while self.parameters.start_time.elapsed() <= self.parameters.soft_timeout
             && best_result.depth <= self.parameters.max_depth
         {
             // create an aspiration window around the best result so far
@@ -258,7 +258,7 @@ impl<'a> Search<'a> {
                 if self.should_stop_searching() {
                     // we have to stop searching now, use the best result we have
                     // no score update
-                    break 'aspiration_window;
+                    break 'deepening;
                 }
             }
 

--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -26,7 +26,12 @@ use itertools::Itertools;
 use uci_parser::{UciInfo, UciResponse, UciSearchOptions};
 
 use crate::{
-    aspiration_window::AspirationWindow, defs::MAX_DEPTH, evaluation::Evaluation, history_table::HistoryTable, score::{MoveOrderScoreType, Score, ScoreType}, ttable::{self, TranspositionTableEntry}
+    aspiration_window::AspirationWindow,
+    defs::MAX_DEPTH,
+    evaluation::Evaluation,
+    history_table::HistoryTable,
+    score::{MoveOrderScoreType, Score, ScoreType},
+    ttable::{self, TranspositionTableEntry},
 };
 use ttable::TranspositionTable;
 

--- a/engine/src/tuneable.rs
+++ b/engine/src/tuneable.rs
@@ -14,6 +14,5 @@
 
 use crate::score::ScoreType;
 
-pub(crate) const MIN_ASPIRATION_WINDOW: ScoreType = 10;
 pub(crate) const MIN_ASPIRATION_DEPTH: ScoreType = 1;
-pub(crate) const ASPIRATION_WINDOW: ScoreType = 6;
+pub(crate) const ASPIRATION_WINDOW: ScoreType = 50;

--- a/engine/src/tuneable.rs
+++ b/engine/src/tuneable.rs
@@ -14,6 +14,6 @@
 
 use crate::score::ScoreType;
 
-pub(crate) const INITIAL_ASPIRATION_WINDOW: ScoreType = 25;
 pub(crate) const MIN_ASPIRATION_WINDOW: ScoreType = 10;
 pub(crate) const MIN_ASPIRATION_DEPTH: ScoreType = 1;
+pub(crate) const ASPIRATION_WINDOW: ScoreType = 6;

--- a/engine/src/tuneable.rs
+++ b/engine/src/tuneable.rs
@@ -1,0 +1,19 @@
+/*
+ * tuneable.rs
+ * Part of the byte-knight project
+ * Created Date: Wednesday, December 11th 2024
+ * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
+ * -----
+ * Last Modified: Wed Dec 11 2024
+ * -----
+ * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
+ * GNU General Public License v3.0 or later
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ */
+
+use crate::score::ScoreType;
+
+pub(crate) const INITIAL_ASPIRATION_WINDOW: ScoreType = 25;
+pub(crate) const MIN_ASPIRATION_WINDOW: ScoreType = 10;
+pub(crate) const MIN_ASPIRATION_DEPTH: ScoreType = 1;

--- a/engine/src/tuneable.rs
+++ b/engine/src/tuneable.rs
@@ -4,7 +4,7 @@
  * Created Date: Wednesday, December 11th 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Wed Dec 11 2024
+ * Last Modified: Thu Dec 12 2024
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later


### PR DESCRIPTION
## Changes

- Added start of a `tunable` file for constants that are part of search and can be tuned later on via SPSA
- Added `AspirationWindow` struct 
- Added more scoring constants

Resolves #52 

```
Elo   | 51.79 +- 20.20 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.28 (-2.94, 2.94) [0.00, 10.00]
Games | N: 588 W: 216 L: 129 D: 243
Penta | [7, 54, 114, 83, 36]
https://pyronomy.pythonanywhere.com/test/385/
```

bench: 1583604