### PR TITLE
fix: properly scaling eval and perspective

### DIFF
--- a/src/bin/hce-tuner/epd_parser.rs
+++ b/src/bin/hce-tuner/epd_parser.rs
@@ -77,10 +77,7 @@ fn parse_epd_line(line: &str) -> Result<TuningPosition> {
         }
     }
 
-    let is_white_relative = match game_result {
-        0.0 | 0.5 | 1.0 => true,
-        _ => false,
-    };
+    let is_white_relative = matches!(game_result, 0.0 | 0.5 | 1.0);
 
     let result = if is_white_relative {
         game_result
@@ -207,9 +204,8 @@ mod tests {
         ];
 
         let mut expected_game_phases: [f64; 10] = [7., 18., 12., 10., 10., 8., 17., 20., 5., 24.];
-        for i in 0..expected_game_phases.len() {
-            // scale to [0, 1]
-            expected_game_phases[i] /= GAME_PHASE_MAX as f64;
+        for phase in &mut expected_game_phases {
+            *phase /= GAME_PHASE_MAX as f64;
         }
 
         const EXPECTED_GAME_RESULTS: [f64; 10] = [0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0];
@@ -225,6 +221,7 @@ mod tests {
             // also verify that the evaluation matches
             let expected_value = eval.eval(board);
 
+            // tuning position evaluation is always from white's perspective
             let val = match board.side_to_move() {
                 Side::White => position.evaluate(&params),
                 Side::Black => -position.evaluate(&params),
@@ -274,7 +271,13 @@ mod tests {
             assert_eq!(position.game_result, expected_game_result);
             assert_eq!(*result, EXPECTED_PARSED_GAME_RESULTS[i]);
             let expected_value = eval.eval(board);
-            let val = position.evaluate(&params);
+
+            // tuning position evaluation is always from white's perspective
+            let val = match board.side_to_move() {
+                Side::White => position.evaluate(&params),
+                Side::Black => -position.evaluate(&params),
+                Side::Both => panic!("Side to move cannot be both."),
+            };
             println!("{} // {}", expected_value, val);
             assert!((expected_value.0 as f64 - val).abs().round() <= 1.0)
         }
@@ -308,7 +311,12 @@ mod tests {
             assert_eq!(position.game_result, EXPECTED_PARSED_GAME_RESULTS[i]);
             assert_eq!(*result, EXPECTED_PARSED_GAME_RESULTS[i]);
             let expected_value = eval.eval(board);
-            let val = position.evaluate(&params);
+            // tuning position evaluation is always from white's perspective
+            let val = match board.side_to_move() {
+                Side::White => position.evaluate(&params),
+                Side::Black => -position.evaluate(&params),
+                Side::Both => panic!("Side to move cannot be both."),
+            };
             println!("{} // {}", expected_value, val);
             assert!((expected_value.0 as f64 - val).abs().round() <= 1.0)
         }

--- a/src/bin/hce-tuner/main.rs
+++ b/src/bin/hce-tuner/main.rs
@@ -1,16 +1,15 @@
-use std::process::exit;
-
 use chess::{
     definitions::NumberOf,
     pieces::{ALL_PIECES, PIECE_NAMES},
 };
-use clap::Parser;
+use clap::{Parser, Subcommand, ValueEnum};
 use indicatif::ParallelProgressIterator;
 use parameters::Parameters;
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 use textplots::{Chart, Plot, Shape};
 use tuner::Tuner;
 use tuner_score::TuningScore;
+use tuning_position::TuningPosition;
 mod epd_parser;
 mod math;
 mod offsets;
@@ -22,24 +21,42 @@ mod tuning_position;
 #[derive(Parser, Debug)]
 #[command(version, about="Texel tuner for HCE in byte-knight", long_about=None)]
 struct Options {
-    #[clap(short, long, help = "Filterd, marked EPD input data.")]
-    input_data: String,
-    #[clap(short, long, help = "Number of epochs to run.")]
-    epochs: Option<usize>,
-    #[clap(
-        long,
-        action,
-        default_value_t = false,
-        help = "Plot k versus error for the given dataset"
-    )]
-    plot_k: bool,
-    #[clap(
-        long,
-        action,
-        default_value_t = false,
-        help = "Compute error of current parameters"
-    )]
-    compute_error: bool,
+    #[command(subcommand)]
+    command: Command,
+}
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
+enum ParameterStartType {
+    Zero,
+    EngineValues,
+    PieceValues,
+}
+
+const INPUT_DATA_HELP: &str = "Filtered, marked EPD or 'book' input data.";
+#[derive(Subcommand, Debug)]
+enum Command {
+    Tune {
+        #[clap(short, long, help = INPUT_DATA_HELP)]
+        input_data: String,
+        #[clap(short, long, help = "Number of epochs to run.")]
+        epochs: Option<usize>,
+        #[arg(value_enum, short, long, help = "How to start the parameters", default_value_t = ParameterStartType::Zero)]
+        param_start_type: ParameterStartType,
+    },
+    PlotK {
+        #[clap(short, long, help = INPUT_DATA_HELP)]
+        input_data: String,
+    },
+    ComputeError {
+        #[clap(short, long, help = INPUT_DATA_HELP)]
+        input_data: String,
+        #[clap(
+            short,
+            long,
+            help = "k value to compute error for (0.009)",
+            default_value_t = 0.009
+        )]
+        k: f64,
+    },
 }
 
 fn print_table(indent: usize, table: &[TuningScore]) {
@@ -76,8 +93,8 @@ fn print_params(params: &Parameters) {
 
 fn plot_k(tuner: &Tuner) {
     let mut points = Vec::new();
-    let data_point_count = 10_000;
-    let k_min = -0.1;
+    let data_point_count = 1_000;
+    let k_min = 0.;
     let k_max = 0.1;
     (0..data_point_count)
         .into_par_iter()
@@ -91,32 +108,52 @@ fn plot_k(tuner: &Tuner) {
 
     Chart::new(180, 60, k_min as f32, k_max as f32)
         .lineplot(&Shape::Points(points.as_slice()))
-        .display();
+        .nice();
+}
+
+fn parse_data(input_data: &str) -> Vec<TuningPosition> {
+    println!("Reading data from: {}", input_data);
+    let positions = epd_parser::parse_epd_file(input_data);
+    // let positions = get_positions();
+    println!("Read {} positions", positions.len());
+    positions
 }
 
 fn main() {
     let options = Options::parse();
-    println!("Reading data from: {}", options.input_data);
-    let positions = epd_parser::parse_epd_file(options.input_data.as_str());
-    // let positions = get_positions();
-    println!("Read {} positions", positions.len());
-
-    let epochs = options.epochs.unwrap_or(10_000);
-    let parameters = Parameters::create_from_engine_values();
-    let mut tuner = tuner::Tuner::new(parameters, &positions, epochs);
-
-    if options.plot_k {
-        plot_k(&tuner);
-        exit(0);
+    match options.command {
+        Command::Tune {
+            input_data,
+            epochs,
+            param_start_type,
+        } => {
+            let positions = parse_data(&input_data);
+            let parameters = match param_start_type {
+                ParameterStartType::Zero => Parameters::default(),
+                ParameterStartType::EngineValues => Parameters::create_from_engine_values(),
+                ParameterStartType::PieceValues => Parameters::create_from_piece_values(),
+            };
+            let epchs = epochs.unwrap_or(10_000);
+            println!(
+                "Tuning parameters from {:?} for {} epochs",
+                param_start_type, epchs
+            );
+            let mut tuner = tuner::Tuner::new(parameters, &positions, epchs);
+            let tuned_results = tuner.tune();
+            print_params(&tuned_results);
+        }
+        Command::PlotK { input_data } => {
+            let positions = parse_data(&input_data);
+            let parameters = Parameters::create_from_engine_values();
+            let tuner = tuner::Tuner::new(parameters, &positions, 10_000);
+            plot_k(&tuner);
+        }
+        Command::ComputeError { input_data, k } => {
+            let positions = parse_data(&input_data);
+            let parameters = Parameters::create_from_engine_values();
+            let tuner = tuner::Tuner::new(parameters, &positions, 10_000);
+            let error = tuner.mean_square_error(k);
+            println!("Error for k {:.8}: {:.8}", k, error);
+        }
     }
-
-    if options.compute_error {
-        let k = tuner.compute_k();
-        let error = tuner.mean_square_error(k);
-        println!("k: {}, error: {}", k, error);
-        exit(0);
-    }
-
-    let tuned_result = tuner.tune();
-    print_params(tuned_result);
 }

--- a/src/bin/hce-tuner/main.rs
+++ b/src/bin/hce-tuner/main.rs
@@ -140,7 +140,7 @@ fn main() {
             );
             let mut tuner = tuner::Tuner::new(parameters, &positions, epchs);
             let tuned_results = tuner.tune();
-            print_params(&tuned_results);
+            print_params(tuned_results);
         }
         Command::PlotK { input_data } => {
             let positions = parse_data(&input_data);

--- a/src/bin/hce-tuner/main.rs
+++ b/src/bin/hce-tuner/main.rs
@@ -33,6 +33,13 @@ struct Options {
         help = "Plot k versus error for the given dataset"
     )]
     plot_k: bool,
+    #[clap(
+        long,
+        action,
+        default_value_t = false,
+        help = "Compute error of current parameters"
+    )]
+    compute_error: bool,
 }
 
 fn print_table(indent: usize, table: &[TuningScore]) {
@@ -103,7 +110,13 @@ fn main() {
         exit(0);
     }
 
-    let tuned_result = tuner.tune();
+    if options.compute_error {
+        let k = tuner.compute_k();
+        let error = tuner.mean_square_error(k);
+        println!("k: {}, error: {}", k, error);
+        exit(0);
+    }
 
+    let tuned_result = tuner.tune();
     print_params(tuned_result);
 }

--- a/src/bin/hce-tuner/parameters.rs
+++ b/src/bin/hce-tuner/parameters.rs
@@ -69,8 +69,7 @@ impl Parameters {
             let sigmoid_result = math::sigmoid(k * point.evaluate(self));
             let term =
                 (point.game_result - sigmoid_result) * (1. - sigmoid_result) * sigmoid_result;
-            let phase_adjustment =
-                term * TuningScore::new(point.phase as f64, 1f64 - point.phase as f64);
+            let phase_adjustment = term * TuningScore::new(point.phase, 1. - point.phase);
 
             for idx in &point.parameter_indexes[Side::White as usize] {
                 gradient[*idx] += phase_adjustment;

--- a/src/bin/hce-tuner/tuner.rs
+++ b/src/bin/hce-tuner/tuner.rs
@@ -32,7 +32,7 @@ impl<'a> Tuner<'a> {
     pub(crate) fn tune(&mut self) -> &Parameters {
         println!("Computing optimal K value...");
         let computed_k: f64 = self.compute_k();
-        println!("Optimal K value: {}", computed_k);
+        println!("Optimal K value: {:.8}", computed_k);
         println!("Using {} positions", self.positions.len());
 
         for epoch in 1..=self.max_epochs {
@@ -102,7 +102,7 @@ impl<'a> Tuner<'a> {
 
     /// Computes the optimal K value to minimize the error of the initial parameters.
     /// Taken from https://github.com/jw1912/hce-tuner/
-    fn compute_k(&self) -> f64 {
+    pub(crate) fn compute_k(&self) -> f64 {
         let mut k = 0.009;
         let delta = 0.00001;
         let goal = 0.000001;

--- a/src/bin/hce-tuner/tuner_score.rs
+++ b/src/bin/hce-tuner/tuner_score.rs
@@ -29,10 +29,15 @@ impl TuningScore {
         Self::new(self.mg().sqrt(), self.eg().sqrt())
     }
 
-    pub fn taper(&self, phase: f64, max_phase: f64) -> f64 {
-        let mg_phase = phase.min(max_phase);
-        let eg_phase = max_phase - mg_phase;
-        (self.mg() * mg_phase + self.eg() * eg_phase) / max_phase
+    /// Taper the score based on the phase of the game.
+    ///
+    /// # Arguments
+    /// * `phase` - The current phase of the game. This should already be scaled to the range [0, max_phase].
+    ///
+    /// # Returns
+    /// The tapered score.
+    pub fn taper(&self, phase: f64) -> f64 {
+        self.mg() * phase + self.eg() * (1. - phase)
     }
 }
 

--- a/src/bin/hce-tuner/tuning_position.rs
+++ b/src/bin/hce-tuner/tuning_position.rs
@@ -1,22 +1,19 @@
 use chess::{definitions::NumberOf, side::Side};
-use engine::hce_values::GAME_PHASE_MAX;
 
 use crate::{math, parameters::Parameters, tuner_score::TuningScore};
 
 pub(crate) struct TuningPosition {
     pub(crate) parameter_indexes: [Vec<usize>; NumberOf::SIDES],
-    pub(crate) phase: usize,
+    pub(crate) phase: f64,
     pub(crate) game_result: f64,
-    pub(crate) side_to_move: f64,
 }
 
 impl TuningPosition {
     pub(crate) fn new(
         white_indexes: Vec<usize>,
         black_indexes: Vec<usize>,
-        phase: usize,
+        phase: f64,
         game_result: f64,
-        side_to_move: f64,
     ) -> Self {
         // Side::White == 0, Side::Black == 1
         let parameter_indexes = [white_indexes, black_indexes];
@@ -24,10 +21,14 @@ impl TuningPosition {
             parameter_indexes,
             phase,
             game_result,
-            side_to_move,
         }
     }
 
+    /// Evaluate the tuning position based on the given parameters from white's perspective.
+    /// # Arguments
+    /// * `parameters` - The parameters to evaluate.
+    /// # Returns
+    /// The evaluated score from white's perspective.
     pub(crate) fn evaluate(&self, parameters: &Parameters) -> f64 {
         let mut score: TuningScore = Default::default();
 
@@ -39,7 +40,7 @@ impl TuningPosition {
             score -= parameters[idx];
         }
 
-        score.taper(self.phase as f64, GAME_PHASE_MAX as f64) * self.side_to_move
+        score.taper(self.phase)
     }
 
     pub(crate) fn error(&self, k: f64, params: &Parameters) -> f64 {


### PR DESCRIPTION
Eval phase is now scaled from [0.0, 1.0] while parsing so we don't need the max game phase while computing in the tuner. Also made sure that tuning evaluation is from white's perspective to be consistent with how to evaluate positions and the tuner scores. Added comments to make this more clear as well.

Fixes #63 
bench: 1583604