### PR TITLE
Improve overall test coverage

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,12 @@
 set windows-shell := ["pwsh.exe", "-NoLogo", "-Command"]
 
+make_dir := if os_family() == "windows" {
+    "New-Item -ItemType Directory -Force"
+} else {
+    "mkdir -p"
+}
+env_var_prefix := if os_family() == "windows" { "$env:" } else { "" }
+
 default: (build)
 
 [group('dev')]
@@ -20,8 +27,8 @@ export LLVM_PROFILE_FILE:="./target/coverage/byte_knight-%p-%m.profraw"
 [doc('Generate test coverage')]
 coverage: (build "debug")
     echo "Running tests with coverage..."
-    mkdir -p target/coverage
-    RUSTFLAGS="-Cinstrument-coverage" \
+    {{ make_dir }} target/coverage
+    {{env_var_prefix}}RUSTFLAGS="-Cinstrument-coverage"; \
     cargo test --workspace -- --skip "perft"
     grcov target/coverage engine/target/coverage chess/target/coverage -s . \
         --binary-path ./target/debug/ --output-types lcov -o ./target/coverage/byte-knight.lcov \

--- a/Justfile
+++ b/Justfile
@@ -118,3 +118,8 @@ cache-main: (build "release")
 compare-to-main engine1: (build "release")
     echo "Comparing {{ engine1 }} to bk-main"
     fastchess -engine cmd="{{ engine1 }}" name="dev" -engine cmd="./bk-main" name="bk-main" -openings file="./data/Pohl.epd" format=epd order=random -each tc=10+0.1 -rounds 200 -repeat -concurrency 8 -sprt elo0=0 elo1=5 alpha=0.05 beta=0.1 model=normalized -output format=cutechess
+
+[group('dev')]
+[doc('Format all Rust code')]
+format:
+    cargo fmt --all

--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ Clone the repo and run:
 cargo run --release
 ```
 
+# Development Dependencies
+
+To run the full suite of supported tests, benchmarks and other development dependencies, you will need the following tools (in addition to Rust and Cargo):
+- [just](https://github.com/casey/just)
+- Rust llvm-profdata component
+  - Install with `rustup component add llvm-tools-preview`
+- [grcov](https://github.com/mozilla/grcov) (Used to generate code coverage reports)
+- [lcov](https://github.com/linux-test-project/lcov) (Required for `genhtml` to create HTML reports from `lcov` data)
+
 # License
 
 The project is licensed under the GPL license. See [LICENSE](LICENSE) for more details.

--- a/chess/src/bitboard.rs
+++ b/chess/src/bitboard.rs
@@ -353,16 +353,49 @@ mod tests {
         let bb2 = Bitboard::new(0x0F0F0F0F0F0F0F0F);
 
         // AND
-        assert_eq!((bb1 & bb2).data, 0);
+        assert_eq!((bb1 & bb2), 0);
 
         // OR
-        assert_eq!((bb1 | bb2).data, 0xFFFFFFFFFFFFFFFF);
+        assert_eq!((bb1 | bb2), 0xFFFFFFFFFFFFFFFF);
 
         // XOR
-        assert_eq!((bb1 ^ bb2).data, 0xFFFFFFFFFFFFFFFF);
+        assert_eq!((bb1 ^ bb2), 0xFFFFFFFFFFFFFFFF);
+        assert_eq!(bb1 ^ 0x0F0F0F0F0F0F0F0F, 0xFFFFFFFFFFFFFFFF);
+        let mut bb_xor = bb1;
+        bb_xor ^= bb2;
+        assert_eq!(bb_xor, 0xFFFFFFFFFFFFFFFF);
 
         // NOT
         assert_eq!((!bb1), 0x0F0F0F0F0F0F0F0F);
+    }
+
+    #[test]
+    fn shifts() {
+        let bb = Bitboard::new(0x8000000000000001);
+
+        assert_eq!(bb << 1, Bitboard::new(0x2));
+        assert_eq!(bb << 2, Bitboard::new(0x4));
+        assert_eq!(bb << Bitboard::new(1), Bitboard::new(0x2));
+        assert_eq!(bb << Bitboard::new(2), Bitboard::new(0x4));
+
+        assert_eq!(bb >> 1, Bitboard::new(0x4000000000000000));
+        assert_eq!(bb >> 2, Bitboard::new(0x2000000000000000));
+        assert_eq!(bb >> Bitboard::new(1), Bitboard::new(0x4000000000000000));
+        assert_eq!(bb >> Bitboard::new(2), Bitboard::new(0x2000000000000000));
+
+        let mut bb_left = bb;
+        bb_left <<= 1;
+        assert_eq!(bb_left, Bitboard::new(0x2));
+        bb_left = bb;
+        bb_left <<= Bitboard::new(1);
+        assert_eq!(bb_left, Bitboard::new(0x2));
+
+        let mut bb_right = bb;
+        bb_right >>= 1;
+        assert_eq!(bb_right, Bitboard::new(0x4000000000000000));
+        bb_right = bb;
+        bb_right >>= Bitboard::new(1);
+        assert_eq!(bb_right, Bitboard::new(0x4000000000000000));
     }
 
     #[test]
@@ -392,5 +425,20 @@ mod tests {
         assert_eq!(original_square, Squares::B4);
         assert_eq!(front_square, Squares::B5);
         assert_eq!(back_square, Squares::B3);
+    }
+
+    #[test]
+    fn hash() {
+        use std::collections::hash_map::HashMap;
+        let mut map = HashMap::new();
+        for sq in 0..64 {
+            let bb = Bitboard::from_square(sq);
+            map.insert(bb, sq);
+        }
+
+        for sq in 0..64 {
+            let bb = Bitboard::from_square(sq);
+            assert_eq!(map.get(&bb), Some(&sq));
+        }
     }
 }

--- a/chess/src/board.rs
+++ b/chess/src/board.rs
@@ -49,6 +49,12 @@ impl Clone for Board {
     }
 }
 
+impl Default for Board {
+    fn default() -> Self {
+        Board::default_board()
+    }
+}
+
 // Private methods
 impl Board {
     /// Create a new board in the default, *uninitialized*, state.

--- a/chess/src/board.rs
+++ b/chess/src/board.rs
@@ -31,6 +31,7 @@ use super::side::Side;
 use super::{bitboard::Bitboard, pieces::Piece};
 
 /// Represents a chess board position.
+#[derive(Debug)]
 pub struct Board {
     piece_bitboards: [[Bitboard; NumberOf::PIECE_TYPES]; NumberOf::SIDES],
     pub(crate) history: BoardHistory,
@@ -934,6 +935,30 @@ mod tests {
         for fen in lines.lines() {
             let board = Board::from_fen(fen).unwrap();
             assert_eq!(fen, board.to_fen());
+        }
+    }
+    #[test]
+    fn from_invalid_fen() {
+        let maybe_board = Board::from_fen("");
+        assert!(maybe_board.is_err());
+        let err = maybe_board.unwrap_err();
+        let message = format!("{}", err);
+        // check that the message contains something about the FEN being empty
+        assert!(message.to_lowercase().contains("empty"));
+    }
+
+    #[test]
+    fn color_on() {
+        let board = Board::default_board();
+        for sq in 0..64 {
+            let color = board.color_on(sq);
+            if sq <= 15 {
+                assert!(color.is_some_and(|c| c == Side::White));
+            } else if sq >= 48 {
+                assert!(color.is_some_and(|c| c == Side::Black));
+            } else {
+                assert!(color.is_none());
+            }
         }
     }
 }

--- a/chess/src/board_state.rs
+++ b/chess/src/board_state.rs
@@ -66,3 +66,28 @@ impl Display for BoardState {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::moves::Move;
+
+    #[test]
+    fn default_board_state() {
+        let board_state = BoardState::default();
+        assert_eq!(board_state.half_move_clock, 0);
+        assert_eq!(board_state.full_move_number, 1);
+        assert_eq!(board_state.side_to_move, Side::White);
+        assert_eq!(board_state.en_passant_square, None);
+        assert_eq!(board_state.castling_rights, CastlingAvailability::NONE);
+        assert_eq!(board_state.zobrist_hash, 0);
+        assert_eq!(board_state.next_move, Move::default());
+    }
+
+    #[test]
+    fn display_board_state() {
+        let board_state = BoardState::new();
+        let expected = "state { half_move_clock: 0, full_move_number: 1, side_to_move: White, en_passant_square: None, castling_rights: 0, zobrist_hash: 0, next_move: a1a1 }";
+        assert_eq!(board_state.to_string(), expected);
+    }
+}

--- a/chess/src/fen.rs
+++ b/chess/src/fen.rs
@@ -246,7 +246,7 @@ fn parse_active_color(board: &mut Board, part: &str) -> FenResult {
     }
 
     // we have validated that the string has a length of 1
-    if let Some(val) = part.trim().chars().nth(0) {
+    if let Some(val) = part.trim().chars().next() {
         if let Ok(side) = Side::try_from(val) {
             board.set_side_to_move(side);
         } else {
@@ -484,12 +484,11 @@ mod tests {
             error
                 .offending_parts
                 .as_ref()
-                .is_some_and(|parts| parts.len() > 0 && parts[0] == FenPart::PiecePlacement)
+                .is_some_and(|parts| !parts.is_empty() && parts[0] == FenPart::PiecePlacement)
         };
 
         let mut board: Board = Default::default();
         let piece_placement_part = parts[0].clone() + "//";
-        println!("Piece placement part: {}", piece_placement_part);
         let result = parse_piece_placement(&mut board, &piece_placement_part);
         assert!(result.is_err());
         let error = result.unwrap_err();
@@ -520,7 +519,7 @@ mod tests {
         assert!(ep_square.is_some());
         let expected_sq = Square::from_file_rank(File::E.to_char(), Rank::R3.as_number())
             .unwrap()
-            .to_square_index() as u8;
+            .to_square_index();
         assert_eq!(ep_square.unwrap(), expected_sq);
 
         let bad_eq_square = "e99";
@@ -541,7 +540,7 @@ mod tests {
         let err = result.unwrap_err();
         assert!(
             err.offending_parts
-                .is_some_and(|parts| parts.len() > 0 && parts[0] == FenPart::CastlingAvailability)
+                .is_some_and(|parts| !parts.is_empty() && parts[0] == FenPart::CastlingAvailability)
         );
 
         // invalid chars
@@ -551,7 +550,7 @@ mod tests {
         let err = result.unwrap_err();
         assert!(
             err.offending_parts
-                .is_some_and(|parts| parts.len() > 0 && parts[0] == FenPart::CastlingAvailability)
+                .is_some_and(|parts| !parts.is_empty() && parts[0] == FenPart::CastlingAvailability)
         );
     }
 
@@ -563,7 +562,7 @@ mod tests {
             error
                 .offending_parts
                 .as_ref()
-                .is_some_and(|parts| parts.len() > 0 && parts[0] == FenPart::ActiveColor)
+                .is_some_and(|parts| !parts.is_empty() && parts[0] == FenPart::ActiveColor)
         };
 
         // empty string

--- a/chess/src/file.rs
+++ b/chess/src/file.rs
@@ -115,4 +115,48 @@ mod tests {
         assert_eq!(File::H.offset(1), None);
         assert_eq!(File::H.offset(-1), Some(File::G));
     }
+
+    #[test]
+    fn to_char() {
+        assert_eq!(File::A.to_char(), 'a');
+        assert_eq!(File::B.to_char(), 'b');
+        assert_eq!(File::C.to_char(), 'c');
+        assert_eq!(File::D.to_char(), 'd');
+        assert_eq!(File::E.to_char(), 'e');
+        assert_eq!(File::F.to_char(), 'f');
+        assert_eq!(File::G.to_char(), 'g');
+        assert_eq!(File::H.to_char(), 'h');
+    }
+
+    #[test]
+    fn from_char() {
+        assert_eq!(File::try_from('a').unwrap(), File::A);
+        assert_eq!(File::try_from('b').unwrap(), File::B);
+        assert_eq!(File::try_from('c').unwrap(), File::C);
+        assert_eq!(File::try_from('d').unwrap(), File::D);
+        assert_eq!(File::try_from('e').unwrap(), File::E);
+        assert_eq!(File::try_from('f').unwrap(), File::F);
+        assert_eq!(File::try_from('g').unwrap(), File::G);
+        assert_eq!(File::try_from('h').unwrap(), File::H);
+
+        for c in 'i'..='z' {
+            assert!(File::try_from(c).is_err());
+        }
+    }
+
+    #[test]
+    fn from_u8() {
+        assert_eq!(File::try_from(0).unwrap(), File::A);
+        assert_eq!(File::try_from(1).unwrap(), File::B);
+        assert_eq!(File::try_from(2).unwrap(), File::C);
+        assert_eq!(File::try_from(3).unwrap(), File::D);
+        assert_eq!(File::try_from(4).unwrap(), File::E);
+        assert_eq!(File::try_from(5).unwrap(), File::F);
+        assert_eq!(File::try_from(6).unwrap(), File::G);
+        assert_eq!(File::try_from(7).unwrap(), File::H);
+
+        for i in 8..=u8::MAX {
+            assert!(File::try_from(i).is_err());
+        }
+    }
 }

--- a/chess/src/magics.rs
+++ b/chess/src/magics.rs
@@ -224,4 +224,36 @@ mod tests {
             indexes.push(index);
         }
     }
+
+    #[test]
+    fn magic_number_display() {
+        // test a1 for the rook
+        let relevant_bits = MoveGenerator::relevant_rook_bits(Squares::A1);
+        let magic_value = 684547693657194778;
+        let magic = MagicNumber::new(
+            relevant_bits,
+            (64 - relevant_bits.as_number().count_ones()) as u8,
+            0,
+            magic_value,
+        );
+
+        assert_eq!(
+            format!("{}", magic),
+            "bb          282578800148862 shift   52 offset      0 magic       684547693657194778"
+        );
+
+        // test c4 for the bishop
+        let relevant_bits = MoveGenerator::relevant_bishop_bits(Squares::C4);
+        let magic_value = BISHOP_MAGIC_VALUES[Squares::C4 as usize];
+        let magic = MagicNumber::new(
+            relevant_bits,
+            (64 - relevant_bits.as_number().count_ones()) as u8,
+            0,
+            magic_value,
+        );
+        assert_eq!(
+            format!("{}", magic),
+            "bb         9024834391117824 shift   57 offset      0 magic       153265359544132100"
+        );
+    }
 }

--- a/chess/src/move_history.rs
+++ b/chess/src/move_history.rs
@@ -15,6 +15,7 @@
 use crate::{board_state::BoardState, definitions::MAX_MOVES};
 
 /// A struct that holds the history of the board states
+#[derive(Debug)]
 pub(crate) struct BoardHistory {
     board_states: Vec<BoardState>,
 }

--- a/chess/src/move_list.rs
+++ b/chess/src/move_list.rs
@@ -97,11 +97,11 @@ mod tests {
             &Square::from_square_index(16),
             None,
         );
-        move_list.push(mv.clone());
+        move_list.push(mv);
         assert_eq!(move_list.len(), 1);
         assert!(!move_list.is_empty());
 
-        move_list.push(mv.clone());
+        move_list.push(mv);
         assert_eq!(move_list.len(), 2);
     }
 
@@ -112,10 +112,10 @@ mod tests {
         assert_eq!(move_list.len(), 0);
         assert!(move_list.is_empty());
 
-        for i in 0..MAX_MOVE_LIST_SIZE {
+        for _ in 0..MAX_MOVE_LIST_SIZE {
             let mv = Move::new_king_move(
-                &Square::from_square_index(3 as u8),
-                &Square::from_square_index(13 as u8),
+                &Square::from_square_index(3_u8),
+                &Square::from_square_index(13_u8),
                 None,
             );
             move_list.push(mv);

--- a/chess/src/move_list.rs
+++ b/chess/src/move_list.rs
@@ -72,3 +72,63 @@ impl MoveList {
         self.moves.clear();
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::square::Square;
+
+    use super::*;
+
+    #[test]
+    fn default() {
+        let move_list: MoveList = Default::default();
+        assert_eq!(move_list.len(), 0);
+        assert!(move_list.is_empty());
+    }
+
+    #[test]
+    fn push() {
+        let mut move_list = MoveList::new();
+        assert_eq!(move_list.len(), 0);
+        assert!(move_list.is_empty());
+
+        let mv = Move::new_king_move(
+            &Square::from_square_index(8),
+            &Square::from_square_index(16),
+            None,
+        );
+        move_list.push(mv.clone());
+        assert_eq!(move_list.len(), 1);
+        assert!(!move_list.is_empty());
+
+        move_list.push(mv.clone());
+        assert_eq!(move_list.len(), 2);
+    }
+
+    #[test]
+    #[should_panic = "MoveList is full"]
+    fn push_with_overflow() {
+        let mut move_list = MoveList::new();
+        assert_eq!(move_list.len(), 0);
+        assert!(move_list.is_empty());
+
+        for i in 0..MAX_MOVE_LIST_SIZE {
+            let mv = Move::new_king_move(
+                &Square::from_square_index(3 as u8),
+                &Square::from_square_index(13 as u8),
+                None,
+            );
+            move_list.push(mv);
+        }
+        assert_eq!(move_list.len(), MAX_MOVE_LIST_SIZE);
+        assert!(!move_list.is_empty());
+
+        // This will panic
+        let mv = Move::new_king_move(
+            &Square::from_square_index(0),
+            &Square::from_square_index(1),
+            None,
+        );
+        move_list.push(mv);
+    }
+}

--- a/chess/src/pieces.rs
+++ b/chess/src/pieces.rs
@@ -186,3 +186,119 @@ impl TryFrom<char> for Piece {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn piece_default() {
+        let piece: Piece = Default::default();
+        assert_eq!(piece, Piece::None);
+    }
+
+    #[test]
+    fn piece_from_u8() {
+        assert_eq!(Piece::try_from(0), Ok(Piece::King));
+        assert_eq!(Piece::try_from(1), Ok(Piece::Queen));
+        assert_eq!(Piece::try_from(2), Ok(Piece::Rook));
+        assert_eq!(Piece::try_from(3), Ok(Piece::Bishop));
+        assert_eq!(Piece::try_from(4), Ok(Piece::Knight));
+        assert_eq!(Piece::try_from(5), Ok(Piece::Pawn));
+        assert_eq!(Piece::try_from(6), Ok(Piece::None));
+        assert_eq!(Piece::try_from(7), Err(()));
+    }
+
+    #[test]
+    fn piece_from_char() {
+        assert_eq!(Piece::try_from('K'), Ok(Piece::King));
+        assert_eq!(Piece::try_from('Q'), Ok(Piece::Queen));
+        assert_eq!(Piece::try_from('R'), Ok(Piece::Rook));
+        assert_eq!(Piece::try_from('B'), Ok(Piece::Bishop));
+        assert_eq!(Piece::try_from('N'), Ok(Piece::Knight));
+        assert_eq!(Piece::try_from('P'), Ok(Piece::Pawn));
+        assert_eq!(Piece::try_from(' '), Err(()));
+    }
+
+    #[test]
+    fn piece_display() {
+        assert_eq!(Piece::King.to_string(), "King");
+        assert_eq!(Piece::Queen.to_string(), "Queen");
+        assert_eq!(Piece::Rook.to_string(), "Rook");
+        assert_eq!(Piece::Bishop.to_string(), "Bishop");
+        assert_eq!(Piece::Knight.to_string(), "Knight");
+        assert_eq!(Piece::Pawn.to_string(), "Pawn");
+        assert_eq!(Piece::None.to_string(), "None");
+    }
+
+    #[test]
+    fn as_char() {
+        assert_eq!(Piece::King.as_char(), 'k');
+        assert_eq!(Piece::Queen.as_char(), 'q');
+        assert_eq!(Piece::Rook.as_char(), 'r');
+        assert_eq!(Piece::Bishop.as_char(), 'b');
+        assert_eq!(Piece::Knight.as_char(), 'n');
+        assert_eq!(Piece::Pawn.as_char(), 'p');
+        assert_eq!(Piece::None.as_char(), ' ');
+    }
+
+    #[test]
+    fn char_roundtrip() {
+        for piece in Piece::iter() {
+            let c = piece.as_char();
+            let piece2 = Piece::try_from(c).unwrap();
+            assert_eq!(piece, piece2);
+        }
+    }
+
+    #[test]
+    fn is_functions() {
+        assert!(Piece::King.is_king());
+        assert!(!Piece::King.is_queen());
+        assert!(!Piece::King.is_rook());
+        assert!(!Piece::King.is_bishop());
+        assert!(!Piece::King.is_knight());
+        assert!(!Piece::King.is_pawn());
+        assert!(!Piece::King.is_none());
+
+        assert!(Piece::Queen.is_queen());
+        assert!(!Piece::Queen.is_king());
+        assert!(!Piece::Queen.is_rook());
+        assert!(!Piece::Queen.is_bishop());
+        assert!(!Piece::Queen.is_knight());
+        assert!(!Piece::Queen.is_pawn());
+        assert!(!Piece::Queen.is_none());
+
+        assert!(Piece::Bishop.is_bishop());
+        assert!(!Piece::Bishop.is_king());
+        assert!(!Piece::Bishop.is_queen());
+        assert!(!Piece::Bishop.is_rook());
+        assert!(!Piece::Bishop.is_knight());
+        assert!(!Piece::Bishop.is_pawn());
+        assert!(!Piece::Bishop.is_none());
+
+        assert!(Piece::Knight.is_knight());
+        assert!(!Piece::Knight.is_king());
+        assert!(!Piece::Knight.is_queen());
+        assert!(!Piece::Knight.is_rook());
+        assert!(!Piece::Knight.is_bishop());
+        assert!(!Piece::Knight.is_pawn());
+        assert!(!Piece::Knight.is_none());
+
+        assert!(Piece::Rook.is_rook());
+        assert!(!Piece::Rook.is_king());
+        assert!(!Piece::Rook.is_queen());
+        assert!(!Piece::Rook.is_bishop());
+        assert!(!Piece::Rook.is_knight());
+        assert!(!Piece::Rook.is_pawn());
+        assert!(!Piece::Rook.is_none());
+
+        assert!(Piece::Pawn.is_pawn());
+        assert!(!Piece::Pawn.is_king());
+        assert!(!Piece::Pawn.is_queen());
+        assert!(!Piece::Pawn.is_rook());
+        assert!(!Piece::Pawn.is_bishop());
+        assert!(!Piece::Pawn.is_knight());
+        assert!(!Piece::Pawn.is_none());
+    }
+}

--- a/chess/src/side.rs
+++ b/chess/src/side.rs
@@ -96,7 +96,7 @@ mod tests {
         let side: Side = Default::default();
         assert_eq!(side, Side::White);
     }
-    
+
     #[test]
     fn side_from_u8() {
         assert_eq!(Side::try_from(0), Ok(Side::White));

--- a/chess/src/side.rs
+++ b/chess/src/side.rs
@@ -87,6 +87,18 @@ impl TryFrom<u8> for Side {
     }
 }
 
+impl TryFrom<char> for Side {
+    type Error = ();
+
+    fn try_from(value: char) -> Result<Self, Self::Error> {
+        match value {
+            'w' => Ok(Self::White),
+            'b' => Ok(Self::Black),
+            _ => Err(()),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -103,6 +115,16 @@ mod tests {
         assert_eq!(Side::try_from(1), Ok(Side::Black));
         assert_eq!(Side::try_from(2), Ok(Side::Both));
         assert_eq!(Side::try_from(3), Err(()));
+    }
+
+    #[test]
+    fn side_from_char() {
+        assert_eq!(Side::try_from('w'), Ok(Side::White));
+        assert_eq!(Side::try_from('b'), Ok(Side::Black));
+
+        for char in ('a'..'z').filter(|val| *val != 'w' && *val != 'b') {
+            assert!(Side::try_from(char).is_err());
+        }
     }
 
     #[test]

--- a/chess/src/side.rs
+++ b/chess/src/side.rs
@@ -122,7 +122,7 @@ mod tests {
         assert_eq!(Side::try_from('w'), Ok(Side::White));
         assert_eq!(Side::try_from('b'), Ok(Side::Black));
 
-        for char in ('a'..'z').filter(|val| *val != 'w' && *val != 'b') {
+        for char in ('a'..='z').filter(|val| *val != 'w' && *val != 'b') {
             assert!(Side::try_from(char).is_err());
         }
     }

--- a/chess/src/side.rs
+++ b/chess/src/side.rs
@@ -86,3 +86,57 @@ impl TryFrom<u8> for Side {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn side_default() {
+        let side: Side = Default::default();
+        assert_eq!(side, Side::White);
+    }
+    
+    #[test]
+    fn side_from_u8() {
+        assert_eq!(Side::try_from(0), Ok(Side::White));
+        assert_eq!(Side::try_from(1), Ok(Side::Black));
+        assert_eq!(Side::try_from(2), Ok(Side::Both));
+        assert_eq!(Side::try_from(3), Err(()));
+    }
+
+    #[test]
+    fn display_side() {
+        assert_eq!(Side::White.to_string(), "W");
+        assert_eq!(Side::Black.to_string(), "B");
+        assert_eq!(Side::Both.to_string(), "W|B");
+    }
+
+    #[test]
+    fn opposite() {
+        assert_eq!(Side::opposite(Side::White), Side::Black);
+        assert_eq!(Side::opposite(Side::Black), Side::White);
+        assert_eq!(Side::opposite(Side::Both), Side::Both);
+    }
+
+    #[test]
+    fn is_white() {
+        assert!(Side::White.is_white());
+        assert!(!Side::Black.is_white());
+        assert!(!Side::Both.is_white());
+    }
+
+    #[test]
+    fn is_black() {
+        assert!(!Side::White.is_black());
+        assert!(Side::Black.is_black());
+        assert!(!Side::Both.is_black());
+    }
+
+    #[test]
+    fn is_both() {
+        assert!(!Side::White.is_both());
+        assert!(!Side::Black.is_both());
+        assert!(Side::Both.is_both());
+    }
+}

--- a/chess/src/zobrist.rs
+++ b/chess/src/zobrist.rs
@@ -20,7 +20,8 @@ use crate::definitions::NumberOf;
 /// A Zobrist hash value.
 pub type ZobristHash = u64;
 
-pub struct ZobristRandomValues {
+#[derive(Debug)]
+pub(crate) struct ZobristRandomValues {
     pub piece_values: [[[u64; NumberOf::SQUARES]; NumberOf::PIECE_TYPES]; NumberOf::SIDES],
     pub castling_values: [u64; NumberOf::CASTLING_OPTIONS],
     pub en_passant_values: [u64; NumberOf::SQUARES + 1],


### PR DESCRIPTION
## Changes:

- Some `Justfile` changes and fixes for generating coverage data across multiple platforms. 
- Added a `coverage-report` recipe for converting `lcov` to `HTML` using `genhtml`
- Updated README with needed developer tools
- Greatly improved test coverage for the `chess` module (resolves #74)


bench: 760228