### PR TITLE
chore: add small LMR offset

### DIFF
--- a/engine/src/lmr.rs
+++ b/engine/src/lmr.rs
@@ -24,6 +24,7 @@ pub(crate) fn formula(depth: usize, move_count: usize) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    const ZERO: f64 = 0.0;
 
     #[test]
     fn test_lmr_formula() {
@@ -31,7 +32,7 @@ mod tests {
         let move_count = 10;
         let result = formula(depth, move_count);
         assert!(result.is_finite());
-        assert!(result > 0.0);
+        assert!(result > ZERO);
     }
 
     #[test]
@@ -39,7 +40,7 @@ mod tests {
         let depth = 0;
         let move_count = 10;
         let result = formula(depth, move_count);
-        assert_eq!(result, LMR_OFFSET);
+        assert_eq!(result, ZERO);
     }
 
     #[test]
@@ -47,6 +48,6 @@ mod tests {
         let depth = 5;
         let move_count = 0;
         let result = formula(depth, move_count);
-        assert_eq!(result, LMR_OFFSET);
+        assert_eq!(result, ZERO);
     }
 }

--- a/engine/src/tuneable.rs
+++ b/engine/src/tuneable.rs
@@ -26,5 +26,5 @@ pub(crate) const IIR_DEPTH_REDUCTION: ScoreType = 1;
 pub(crate) const NMP_MIN_DEPTH: ScoreType = 3;
 pub(crate) const NMP_DEPTH_REDUCTION: ScoreType = 2;
 
-pub(crate) const LMR_OFFSET: f64 = 0.0;
+pub(crate) const LMR_OFFSET: f64 = 0.2;
 pub(crate) const LMR_SCALING_FACTOR: f64 = 3.0;


### PR DESCRIPTION
bench: 3360896

SPRT:
```
Elo   | 10.52 +- 5.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4788 W: 1014 L: 869 D: 2905
Penta | [63, 513, 1126, 600, 92]
https://pyronomy.pythonanywhere.com/test/2336/
```