### PR TITLE
fix: clamp negative times  with `go` uci command

### DIFF
--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -12,6 +12,7 @@ uci-parser = { version = "1.1.0", features = [
     "parse-go-perft",
     "parse-position-kiwipete",
     "types",
+    "clamp-negatives",
 ] }
 rand = { version = "0.9.0", features = ["small_rng"] }
 arrayvec = "0.7.6"


### PR DESCRIPTION
Turn on the `clamp-negatives` feature for the uci-parser so that negative values do not throw an error in the engine.
Resolves #100

bench: 2517656