### PR TITLE
fix: output correct PV

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -50,5 +50,10 @@
         "Tsouchlos",
         "zobrist"
     ],
-    "makefile.configureOnOpen": false
+    "makefile.configureOnOpen": false,
+    "files.readonlyInclude": {
+        "**/.cargo/registry/src/**/*.rs": true,
+        "**/.cargo/git/checkouts/**/*.rs": true,
+        "**/lib/rustlib/src/rust/library/**/*.rs": true,
+    },
 }

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -14,6 +14,7 @@ mod lmr;
 mod move_order;
 pub(crate) mod node_types;
 pub mod phased_score;
+pub(crate) mod principle_variation;
 pub mod score;
 pub mod search;
 pub mod search_thread;

--- a/engine/src/principle_variation.rs
+++ b/engine/src/principle_variation.rs
@@ -1,0 +1,36 @@
+use anyhow::Result;
+use arrayvec::ArrayVec;
+use chess::{definitions::MAX_MOVES, moves::Move};
+
+#[derive(Debug)]
+pub(crate) struct PrincipleVariation {
+    data: ArrayVec<Move, MAX_MOVES>,
+}
+
+impl Default for PrincipleVariation {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PrincipleVariation {
+    pub(crate) fn new() -> Self {
+        Self {
+            data: ArrayVec::new(),
+        }
+    }
+
+    pub(crate) fn push(&mut self, m: Move) -> Result<()> {
+        let push_result = self.data.try_push(m);
+        Ok(push_result?)
+    }
+
+    pub(crate) fn extend(&mut self, m: Move, pv: &Self) -> Result<()> {
+        self.push(m)?;
+        Ok(self.data.try_extend_from_slice(pv.data.as_slice())?)
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.data.clear();
+    }
+}

--- a/engine/src/principle_variation.rs
+++ b/engine/src/principle_variation.rs
@@ -143,7 +143,7 @@ mod tests {
 
         // Fill the principle variation to its maximum size
         for _ in 0..MAX_MOVES {
-           pv.push(move1);
+            pv.push(move1);
         }
 
         // Attempt to push another move, which should fail

--- a/engine/src/principle_variation.rs
+++ b/engine/src/principle_variation.rs
@@ -46,14 +46,9 @@ impl PrincipleVariation {
         self.data.clear();
     }
 
-    pub(crate) fn len(&self) -> usize {
-        self.data.len()
-    }
-
     pub(crate) fn iter(&self) -> impl Iterator<Item = &Move> {
         self.data.iter()
     }
-    
 }
 
 #[cfg(test)]

--- a/engine/src/principle_variation.rs
+++ b/engine/src/principle_variation.rs
@@ -37,7 +37,9 @@ impl PrincipleVariation {
         Ok(push_result?)
     }
 
+    #[inline(always)]
     pub(crate) fn extend(&mut self, m: Move, pv: &Self) -> Result<()> {
+        self.clear();
         self.push(m)?;
         Ok(self.data.try_extend_from_slice(pv.data.as_slice())?)
     }

--- a/engine/src/principle_variation.rs
+++ b/engine/src/principle_variation.rs
@@ -37,6 +37,14 @@ impl PrincipleVariation {
         Ok(push_result?)
     }
 
+    /// Extend the current [PrincipleVariation] with the given move and another principle variation.
+    ///
+    /// This will clear the current PV and append the given move and [PrincipleVariation].
+    ///
+    /// # Arguments:
+    ///
+    /// - m: The new move to add to the principle variation.
+    /// - pv: The principle variation to append to the current variation.
     #[inline(always)]
     pub(crate) fn extend(&mut self, m: Move, pv: &Self) -> Result<()> {
         self.clear();
@@ -44,10 +52,12 @@ impl PrincipleVariation {
         Ok(self.data.try_extend_from_slice(pv.data.as_slice())?)
     }
 
+    /// Clear the principle variation.
     pub(crate) fn clear(&mut self) {
         self.data.clear();
     }
 
+    /// Returns an iterator to the underlying data of the [PrincipleVariation].
     pub(crate) fn iter(&self) -> impl Iterator<Item = &Move> {
         self.data.iter()
     }

--- a/engine/src/principle_variation.rs
+++ b/engine/src/principle_variation.rs
@@ -33,8 +33,15 @@ impl PrincipleVariation {
     ///
     /// Empty Result<> on success or an error if the underlying ArrayVec
     /// is full before trying to push.
+    #[allow(clippy::panic)]
     pub(crate) fn push(&mut self, m: Move) {
-        self.data.push(m);
+        self.data.try_push(m).unwrap_or_else(|err| {
+            panic!(
+                "Error extending PV of size {} when adding {}\n {err}",
+                self.data.len(),
+                m
+            );
+        })
     }
 
     /// Extend the current [PrincipleVariation] with the given move and another principle variation.
@@ -136,7 +143,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "Error extending PV")]
     fn extending_or_pushing_move_past_max_size_panics() {
         let (move1, move2) = make_moves();
         let mut pv = PrincipleVariation::new();

--- a/engine/src/principle_variation.rs
+++ b/engine/src/principle_variation.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use arrayvec::ArrayVec;
 use chess::{definitions::MAX_MOVES, moves::Move};
 
+/// Represents the [Principle Variation](https://www.chessprogramming.org/Principal_Variation) during a search.
 #[derive(Debug)]
 pub(crate) struct PrincipleVariation {
     data: ArrayVec<Move, MAX_MOVES>,
@@ -14,12 +15,23 @@ impl Default for PrincipleVariation {
 }
 
 impl PrincipleVariation {
+    /// Create a new, empty ['PrincipleVariation'].
     pub(crate) fn new() -> Self {
         Self {
             data: ArrayVec::new(),
         }
     }
 
+    /// Push a move to the ['PrincipleVariation'].
+    ///
+    /// # Arguments:
+    ///
+    /// - m: The new move to add to the principle variation.
+    ///
+    /// # Returns:
+    ///
+    /// Empty Result<> on success or an error if the underlying ArrayVec
+    /// is full before trying to push.
     pub(crate) fn push(&mut self, m: Move) -> Result<()> {
         let push_result = self.data.try_push(m);
         Ok(push_result?)
@@ -32,5 +44,108 @@ impl PrincipleVariation {
 
     pub(crate) fn clear(&mut self) {
         self.data.clear();
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &Move> {
+        self.data.iter()
+    }
+    
+}
+
+#[cfg(test)]
+mod tests {
+    use chess::{definitions::Squares, moves::MoveDescriptor, pieces::Piece, square::Square};
+
+    use super::*;
+
+    fn make_moves() -> (Move, Move) {
+        let move1 = Move::new(
+            &Square::from_square_index(Squares::E2),
+            &Square::from_square_index(Squares::E4),
+            MoveDescriptor::PawnTwoUp,
+            Piece::Pawn,
+            None,
+            None,
+        );
+
+        let move2 = Move::new(
+            &Square::from_square_index(Squares::E7),
+            &Square::from_square_index(Squares::E5),
+            MoveDescriptor::PawnTwoUp,
+            Piece::Pawn,
+            None,
+            None,
+        );
+
+        (move1, move2)
+    }
+
+    #[test]
+    fn add_moves_to_principle_variation() {
+        let mut pv = PrincipleVariation::new();
+
+        let (move1, move2) = make_moves();
+
+        // Push moves to the principle variation
+        assert!(pv.push(move1).is_ok());
+        assert!(pv.push(move2).is_ok());
+
+        // Check that the moves are in the principle variation
+        assert_eq!(pv.data.len(), 2);
+    }
+
+    #[test]
+    fn extend_principle_variation() {
+        let mut pv = PrincipleVariation::new();
+
+        let (move1, move2) = make_moves();
+
+        // Push the first move to the principle variation
+        assert!(pv.push(move1).is_ok());
+
+        // Create a new principle variation to extend from
+        let mut pv2 = PrincipleVariation::new();
+        assert!(pv2.push(move2).is_ok());
+
+        let pv_len_before = pv.data.len();
+        // Extend the original principle variation with the new one
+        assert!(pv.extend(move1, &pv2).is_ok());
+
+        // Check that the moves are in the principle variation
+        assert_eq!(pv.data.len(), pv_len_before + 1 + pv2.data.len());
+    }
+
+    #[test]
+    fn extending_or_pushing_move_past_max_size_fails() {
+        let (move1, move2) = make_moves();
+        let mut pv = PrincipleVariation::new();
+
+        // Fill the principle variation to its maximum size
+        for _ in 0..MAX_MOVES {
+            assert!(pv.push(move1).is_ok());
+        }
+
+        // Attempt to push another move, which should fail
+        assert!(pv.push(move2).is_err());
+
+        // reset
+        pv = PrincipleVariation::new();
+        let mut pv2 = PrincipleVariation::new();
+
+        // Fill the principle variation to its maximum size
+        for _ in 0..MAX_MOVES - 10 {
+            assert!(pv.push(move1).is_ok());
+        }
+
+        for _ in 0..10 {
+            assert!(pv2.push(move2).is_ok());
+        }
+
+        // Attempt to extend the principle variation with another one that would exceed the max size
+        assert!(pv.extend(move2, &pv2).is_err());
     }
 }

--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -469,8 +469,7 @@ impl<'a> Search<'a> {
                 best_score = score;
                 best_move = Some(mv);
                 if Node::PV {
-                    pv.extend(mv, &local_pv)
-                        .expect("Could not extend PV - have you allocated enough space?");
+                    pv.extend(mv, &local_pv);
                 }
 
                 alpha_use = alpha_use.max(best_score);
@@ -707,8 +706,7 @@ impl<'a> Search<'a> {
 
                 // extend PV if we're in a PV node
                 if Node::PV {
-                    pv.extend(mv, &local_pv)
-                        .expect("Could not extend PV - have you allocated enough space?");
+                    pv.extend(mv, &local_pv);
                 }
 
                 if score >= beta {

--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -4,7 +4,7 @@
  * Created Date: Thursday, November 21st 2024
  * Author: Paul Tsouchlos (DeveloperPaul123) (developer.paul.123@gmail.com)
  * -----
- * Last Modified: Tue May 06 2025
+ * Last Modified: Wed May 14 2025
  * -----
  * Copyright (c) 2024 Paul Tsouchlos (DeveloperPaul123)
  * GNU General Public License v3.0 or later
@@ -247,12 +247,6 @@ impl<'a> Search<'a> {
         let mut board_cpy = board.clone();
         let all_ok = pv.iter().all(|mv| {
             let mv_ok = board_cpy.make_move(mv, &self.move_gen);
-            if mv_ok.is_ok() {
-                board_cpy
-                    .unmake_move()
-                    .expect("Unmake move failed during PV check.")
-            }
-
             mv_ok.is_ok()
         });
         if !all_ok {
@@ -701,7 +695,7 @@ impl<'a> Search<'a> {
             let score = if board.is_draw() {
                 Score::DRAW
             } else {
-                let eval = -self.quiescence::<Node>(board, -beta, -alpha_use, pv);
+                let eval = -self.quiescence::<Node>(board, -beta, -alpha_use, &mut local_pv);
                 self.nodes += 1;
                 eval
             };

--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -479,7 +479,7 @@ impl<'a> Search<'a> {
                     // update history table for quiets
                     if mv.is_quiet() {
                         // calculate history bonus
-                        let bonus = 300 * depth - 250;
+                        let bonus = depth.wrapping_mul(300) - 250;
                         self.history_table.update(
                             board.side_to_move(),
                             mv.piece(),

--- a/engine/src/search_thread.rs
+++ b/engine/src/search_thread.rs
@@ -86,7 +86,7 @@ impl SearchThread {
 
         let handle = std::thread::Builder::new()
             .name("bk-search-thread".to_string())
-            .stack_size(4 * 1024 * 1024) // 4 MiB
+            .stack_size(8 * 1024 * 1024) // 8 MiB
             .spawn(move || {
                 let mut stdout = std::io::stdout();
                 'search_loop: loop {

--- a/engine/src/search_thread.rs
+++ b/engine/src/search_thread.rs
@@ -84,40 +84,44 @@ impl SearchThread {
         let stop_flag_clone = stop_flag.clone();
         let is_searching_clone = is_searching.clone();
 
-        let handle = std::thread::spawn(move || {
-            let mut stdout = std::io::stdout();
-            'search_loop: loop {
-                let value = receiver.recv().unwrap();
-                match value {
-                    SearchThreadValue::Params(mut board, params, ttable, history) => {
-                        let mut tt = ttable.lock().unwrap();
-                        let mut hist_table = history.lock().unwrap();
-                        let flag = stop_flag.clone();
-                        is_searching.store(true, Ordering::Relaxed);
-                        let result = Search::new(&params, &mut tt, &mut hist_table)
-                            .search(&mut board, Some(flag));
-                        is_searching.store(false, Ordering::Relaxed);
-                        let best_move = result.best_move;
-                        let move_output = UciResponse::BestMove {
-                            bestmove: best_move
-                                .map(|bot_move| move_to_uci_move(&bot_move).to_string()),
-                            ponder: None,
-                        };
-                        writeln!(
-                            stdout,
-                            "{}",
-                            // TODO: Ponder
-                            move_output
-                        )
-                        .unwrap();
-                    }
+        let handle = std::thread::Builder::new()
+            .name("bk-search-thread".to_string())
+            .stack_size(4 * 1024 * 1024) // 4 MiB
+            .spawn(move || {
+                let mut stdout = std::io::stdout();
+                'search_loop: loop {
+                    let value = receiver.recv().unwrap();
+                    match value {
+                        SearchThreadValue::Params(mut board, params, ttable, history) => {
+                            let mut tt = ttable.lock().unwrap();
+                            let mut hist_table = history.lock().unwrap();
+                            let flag = stop_flag.clone();
+                            is_searching.store(true, Ordering::Relaxed);
+                            let result = Search::new(&params, &mut tt, &mut hist_table)
+                                .search(&mut board, Some(flag));
+                            is_searching.store(false, Ordering::Relaxed);
+                            let best_move = result.best_move;
+                            let move_output = UciResponse::BestMove {
+                                bestmove: best_move
+                                    .map(|bot_move| move_to_uci_move(&bot_move).to_string()),
+                                ponder: None,
+                            };
+                            writeln!(
+                                stdout,
+                                "{}",
+                                // TODO: Ponder
+                                move_output
+                            )
+                            .unwrap();
+                        }
 
-                    SearchThreadValue::Exit => {
-                        break 'search_loop;
+                        SearchThreadValue::Exit => {
+                            break 'search_loop;
+                        }
                     }
                 }
-            }
-        });
+            })
+            .unwrap();
 
         SearchThread {
             sender,


### PR DESCRIPTION
This PR fixes the `pv` output for `byte-knight`. We now output a legit principle variation instead of just the best move. Also fixed a couple minor bugs regarding stack size on `std::thread` and a value overflow when computing the history bonus/malus (see #102). 

Fixes #72 

STC regression test
```
Elo   | 1.30 +- 3.91 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-7.00, 0.00]
Games | N: 8580 W: 1450 L: 1418 D: 5712
Penta | [71, 887, 2367, 869, 96]
https://pyronomy.pythonanywhere.com/test/2692/
```

bench: 2517656